### PR TITLE
Fix TypeScript response type

### DIFF
--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -357,7 +357,10 @@ export class ApiService {
   }
 
   downloadExecutionFile(id: number, type: 'report' | 'evidence'): Observable<Blob> {
-    return this.http.get(`${this.baseUrl}/executions/${id}/${type}`, { headers: this.getHeaders(), responseType: 'blob' as any });
+    return this.http.get(`${this.baseUrl}/executions/${id}/${type}`, {
+      headers: this.getHeaders(),
+      responseType: 'blob'
+    });
   }
 
   isAuthenticated(): boolean {


### PR DESCRIPTION
## Summary
- correct file download responseType in `api.service`

## Testing
- `npm install`
- `npx -p @angular/cli ng build --configuration development`

------
https://chatgpt.com/codex/tasks/task_e_684b4a6f81c4832f847debade4e68b3a