### PR TITLE
Implement basic page permissions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -41,6 +41,12 @@ Al iniciar la aplicación se crean automáticamente los roles:
 
 También se genera el usuario inicial `admin` con la contraseña `admin` perteneciente al rol **Administrador**.
 
+Ahora cada rol puede tener permisos asociados a las páginas del frontend. Usa los siguientes endpoints para administrarlos:
+
+- `GET /roles/{id}/permissions` listar permisos de un rol
+- `POST /roles/{id}/permissions` agregar un permiso enviando `{ "page": "nombre" }`
+- `DELETE /roles/{id}/permissions/{page}` eliminar un permiso
+
 ## Clientes y proyectos
 
 Los clientes y proyectos pueden gestionarse únicamente por usuarios con rol **Administrador**. Un cliente puede tener varios proyectos y ambos pueden inactivarse. Los analistas se asignan a los proyectos y solamente los analistas asignados (o los usuarios Administrador) pueden consultarlos.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,6 +11,19 @@ class Role(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, nullable=False)
 
+
+class PagePermission(Base):
+    __tablename__ = "permissions"
+    __table_args__ = (
+        UniqueConstraint("role_id", "page", name="uix_role_page"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+    page = Column(String, nullable=False)
+
+    role = relationship("Role", backref="permissions")
+
 class User(Base):
     __tablename__ = "users"
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -17,6 +17,22 @@ class Role(RoleBase):
     class Config:
         orm_mode = True
 
+
+class PermissionBase(BaseModel):
+    page: str
+
+
+class PermissionCreate(PermissionBase):
+    pass
+
+
+class Permission(PermissionBase):
+    id: int
+    role_id: int
+
+    class Config:
+        orm_mode = True
+
 class TestBase(BaseModel):
     name: str
     description: Optional[str] = None


### PR DESCRIPTION
## Summary
- expand README with permission management docs
- add `PagePermission` model
- implement permission CRUD endpoints and user permission listing
- add `require_page_permission` dependency
- expose new schemas for permissions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python generate_postman.py` *(fails: bcrypt warning but collection generated)*

------
https://chatgpt.com/codex/tasks/task_e_684b75a2af5c832fb598b810618c4042