### PR TITLE
Add full Test Plan management UI

### DIFF
--- a/frontend/src/app/components/test-plans/test-plan-form.component.ts
+++ b/frontend/src/app/components/test-plans/test-plan-form.component.ts
@@ -1,0 +1,117 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TestPlan, TestPlanCreate } from '../../models';
+import { TestPlanService } from '../../services/test-plan.service';
+
+@Component({
+  selector: 'app-test-plan-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="plan-form">
+      <h2>{{ plan ? 'Editar' : 'Crear' }} Plan de Prueba</h2>
+      <form (ngSubmit)="submit()">
+        <div class="form-group">
+          <label>Nombre</label>
+          <input class="form-control" [(ngModel)]="form.nombre" name="nombre" required minlength="5">
+        </div>
+        <div class="form-group">
+          <label>Objetivo</label>
+          <textarea class="form-control" [(ngModel)]="form.objetivo" name="objetivo"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Alcance</label>
+          <textarea class="form-control" [(ngModel)]="form.alcance" name="alcance"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Criterios de Entrada</label>
+          <textarea class="form-control" [(ngModel)]="form.criterios_entrada" name="entrada"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Criterios de Salida</label>
+          <textarea class="form-control" [(ngModel)]="form.criterios_salida" name="salida"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Estrategia</label>
+          <textarea class="form-control" [(ngModel)]="form.estrategia" name="estrategia"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Responsables</label>
+          <input class="form-control" [(ngModel)]="form.responsables" name="responsables">
+        </div>
+        <div class="form-group d-flex gap-2">
+          <div class="flex-fill">
+            <label>Fecha Inicio</label>
+            <input type="date" class="form-control" [(ngModel)]="form.fecha_inicio" name="fecha_inicio">
+          </div>
+          <div class="flex-fill">
+            <label>Fecha Fin</label>
+            <input type="date" class="form-control" [(ngModel)]="form.fecha_fin" name="fecha_fin">
+          </div>
+        </div>
+        <div class="form-group">
+          <label>Historias BDD</label>
+          <textarea class="form-control" [(ngModel)]="form.historias_bdd" name="historias"></textarea>
+        </div>
+        <div class="mt-3">
+          <button type="submit" class="btn btn-primary mr-2">Guardar</button>
+          <button type="button" class="btn btn-secondary" (click)="cancel.emit()">Cancelar</button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .plan-form { padding: 1rem; }
+    .form-group { margin-bottom: 1rem; }
+    .gap-2 { gap: 0.5rem; }
+    textarea { resize: vertical; }
+    .mr-2 { margin-right: 0.5rem; }
+  `]
+})
+export class TestPlanFormComponent {
+  @Input() plan: TestPlan | null = null;
+  @Output() saved = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  form: TestPlanCreate = {
+    nombre: '',
+    objetivo: '',
+    alcance: '',
+    criterios_entrada: '',
+    criterios_salida: '',
+    estrategia: '',
+    responsables: '',
+    fecha_inicio: '',
+    fecha_fin: '',
+    historias_bdd: ''
+  };
+
+  constructor(private service: TestPlanService) {}
+
+  ngOnChanges() {
+    if (this.plan) {
+      this.form = { ...this.plan };
+    } else {
+      this.form = {
+        nombre: '',
+        objetivo: '',
+        alcance: '',
+        criterios_entrada: '',
+        criterios_salida: '',
+        estrategia: '',
+        responsables: '',
+        fecha_inicio: '',
+        fecha_fin: '',
+        historias_bdd: ''
+      };
+    }
+  }
+
+  submit() {
+    const obs = this.plan ?
+      this.service.updateTestPlan(this.plan.id, this.form) :
+      this.service.createTestPlan(this.form);
+    obs.subscribe(() => this.saved.emit());
+  }
+}

--- a/frontend/src/app/components/test-plans/test-plans.component.ts
+++ b/frontend/src/app/components/test-plans/test-plans.component.ts
@@ -1,20 +1,94 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TestPlan } from '../../models';
+import { TestPlanService } from '../../services/test-plan.service';
+import { TestPlanFormComponent } from './test-plan-form.component';
 
 @Component({
   selector: 'app-test-plans',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule, TestPlanFormComponent],
   template: `
     <div class="main-panel">
       <h1>Planes de Prueba</h1>
-      <p class="text-secondary">Gestiona los planes de prueba del sistema</p>
-      
-      <div class="section">
-        <h2>Próximamente</h2>
-        <p>Esta funcionalidad estará disponible próximamente.</p>
+      <div class="mb-3 d-flex gap-2">
+        <input class="form-control" [(ngModel)]="search" placeholder="Buscar" (ngModelChange)="filter()">
+        <button class="btn btn-primary" (click)="new()">Nuevo</button>
       </div>
+      <table class="table table-bordered" *ngIf="filtered.length > 0">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Objetivo</th>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let p of filtered">
+            <td>{{ p.nombre }}</td>
+            <td>{{ p.objetivo || '-' }}</td>
+            <td>{{ p.fecha_inicio || '-' }}</td>
+            <td>{{ p.fecha_fin || '-' }}</td>
+            <td>
+              <button class="btn btn-sm btn-secondary mr-2" (click)="edit(p)">Editar</button>
+              <button class="btn btn-sm btn-danger" (click)="remove(p)">Eliminar</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div *ngIf="filtered.length === 0">No hay planes de prueba.</div>
+
+      <app-test-plan-form *ngIf="showForm" [plan]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-test-plan-form>
     </div>
-  `
+  `,
+  styles: [`
+    .gap-2 { gap: 0.5rem; }
+    .mr-2 { margin-right: 0.25rem; }
+  `]
 })
-export class TestPlansComponent {}
+export class TestPlansComponent implements OnInit {
+  plans: TestPlan[] = [];
+  filtered: TestPlan[] = [];
+  search = '';
+  showForm = false;
+  editing: TestPlan | null = null;
+
+  constructor(private service: TestPlanService) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.service.getTestPlans().subscribe(p => { this.plans = p; this.filter(); });
+  }
+
+  filter() {
+    const term = this.search.toLowerCase();
+    this.filtered = this.plans.filter(p => p.nombre.toLowerCase().includes(term));
+  }
+
+  new() {
+    this.editing = null;
+    this.showForm = true;
+  }
+
+  edit(p: TestPlan) {
+    this.editing = p;
+    this.showForm = true;
+  }
+
+  remove(p: TestPlan) {
+    if (confirm('¿Eliminar plan de prueba?')) {
+      this.service.deleteTestPlan(p.id).subscribe(() => this.load());
+    }
+  }
+
+  onSaved() {
+    this.showForm = false;
+    this.load();
+  }
+}

--- a/frontend/src/app/services/test-plan.service.ts
+++ b/frontend/src/app/services/test-plan.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { TestPlan, TestPlanCreate } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class TestPlanService {
+  constructor(private api: ApiService) {}
+
+  getTestPlans(): Observable<TestPlan[]> {
+    return this.api.getTestPlans();
+  }
+
+  getTestPlan(id: number): Observable<TestPlan> {
+    return this.api.getTestPlan(id);
+  }
+
+  createTestPlan(plan: TestPlanCreate): Observable<TestPlan> {
+    return this.api.createTestPlan(plan);
+  }
+
+  updateTestPlan(id: number, plan: TestPlanCreate): Observable<TestPlan> {
+    return this.api.updateTestPlan(id, plan);
+  }
+
+  deleteTestPlan(id: number): Observable<any> {
+    return this.api.deleteTestPlan(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement TestPlanService for CRUD operations
- create TestPlanFormComponent with ISTQB style fields
- flesh out TestPlansComponent to list, create, edit and delete

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b76093644832f9128c7b83ab5a222