### PR TITLE
Implement login redirects by role and new role

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,8 @@ Al iniciar la aplicación se crean automáticamente los roles:
 - Arquitecto de Automatización
 - Automation Engineer
 - Analista de Pruebas con skill de automatización
+- Automatizador de Pruebas
+- Gerente de servicios
 
 También se genera el usuario inicial `admin` con la contraseña `admin` perteneciente al rol **Administrador**.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,8 @@ def init_data():
             "Arquitecto de Automatización",
             "Automation Engineer",
             "Automatizador de Pruebas",
-            "Analista de Pruebas con skill de automatización"            
+            "Analista de Pruebas con skill de automatización",
+            "Gerente de servicios",
         ]
         for name in predefined:
             if not db.query(models.Role).filter(models.Role.name == name).first():
@@ -24,9 +25,15 @@ def init_data():
 
         admin = db.query(models.User).filter(models.User.username == "admin").first()
         if not admin:
-            admin_role = db.query(models.Role).filter(models.Role.name == "Administrador").first()
+            admin_role = (
+                db.query(models.Role)
+                .filter(models.Role.name == "Administrador")
+                .first()
+            )
             hashed = deps.get_password_hash("admin")
-            admin = models.User(username="admin", hashed_password=hashed, role=admin_role)
+            admin = models.User(
+                username="admin", hashed_password=hashed, role=admin_role
+            )
             db.add(admin)
             db.commit()
     finally:

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -51,6 +51,10 @@ export const routes: Routes = [
     loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent)
   },
   {
+    path: 'client-admin',
+    loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent)
+  },
+  {
     path: 'actors',
     loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent)
   },

--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../services/api.service';
+import { Client, Project, User } from '../../models';
+
+@Component({
+  selector: 'app-client-admin',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="main-panel">
+      <h1>Administración de Clientes</h1>
+      <div *ngFor="let c of clients" class="mb-4">
+        <h3>{{ c.name }}</h3>
+        <ul class="list-group">
+          <li class="list-group-item" *ngFor="let p of projectsByClient(c.id)">
+            {{ p.name }} - Analistas:
+            <span *ngFor="let a of p.analysts; let i = index">
+              {{ a.username }}<span *ngIf="i < p.analysts.length - 1">, </span>
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  `
+})
+export class ClientAdminComponent implements OnInit {
+  clients: Client[] = [];
+  projects: Project[] = [];
+  users: User[] = [];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  loadData() {
+    this.api.getClients().subscribe(cs => (this.clients = cs));
+    this.api.getProjects().subscribe(ps => (this.projects = ps));
+    this.api.getUsers().subscribe(us => (this.users = us));
+  }
+
+  projectsByClient(clientId: number): Project[] {
+    return this.projects.filter(p => p.client_id === clientId);
+  }
+}

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -164,7 +164,25 @@ export class LoginComponent {
 
     this.apiService.login(this.credentials).subscribe({
       next: () => {
-        this.router.navigate(['/dashboard']);
+        this.apiService.getCurrentUser().subscribe({
+          next: (user) => {
+            const role = user.role?.name || '';
+            this.isLoading = false;
+            if (role === 'Administrador') {
+              this.router.navigate(['/users']);
+            } else if (role === 'Arquitecto de Automatización' || role === 'Automation Engineer') {
+              this.router.navigate(['/actions']);
+            } else if (role === 'Gerente de servicios') {
+              this.router.navigate(['/client-admin']);
+            } else {
+              this.router.navigate(['/dashboard']);
+            }
+          },
+          error: () => {
+            this.isLoading = false;
+            this.router.navigate(['/dashboard']);
+          }
+        });
       },
       error: (error) => {
         this.isLoading = false;


### PR DESCRIPTION
## Summary
- add service manager role in FastAPI init data
- document new roles in backend README
- create ClientAdminComponent and route
- add role-based redirects on login

## Testing
- `pytest -q`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b78e91b50832fbc872a655ffac840