### PR TITLE
Add client CRUD UI

### DIFF
--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -2,17 +2,24 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
+import { ClientService } from '../../services/client.service';
 import { Client, Project, User } from '../../models';
+import { ClientFormComponent } from './client-form.component';
 
 @Component({
   selector: 'app-client-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ClientFormComponent],
   template: `
     <div class="main-panel">
       <h1>Administración de Clientes</h1>
+      <button class="btn btn-primary mb-3" (click)="new()">Nuevo Cliente</button>
       <div *ngFor="let c of clients" class="mb-4">
-        <h3>{{ c.name }}</h3>
+        <h3>
+          {{ c.name }}
+          <button class="btn btn-sm btn-secondary ms-2" (click)="edit(c)">Editar</button>
+          <button class="btn btn-sm btn-danger ms-2" (click)="remove(c)">Eliminar</button>
+        </h3>
         <ul class="list-group">
           <li class="list-group-item" *ngFor="let p of projectsByClient(c.id)">
             {{ p.name }} - Analistas:
@@ -22,6 +29,8 @@ import { Client, Project, User } from '../../models';
           </li>
         </ul>
       </div>
+
+      <app-client-form *ngIf="showForm" [client]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-client-form>
     </div>
   `
 })
@@ -29,20 +38,43 @@ export class ClientAdminComponent implements OnInit {
   clients: Client[] = [];
   projects: Project[] = [];
   users: User[] = [];
+  showForm = false;
+  editing: Client | null = null;
 
-  constructor(private api: ApiService) {}
+  constructor(private api: ApiService, private clientService: ClientService) {}
 
   ngOnInit() {
     this.loadData();
   }
 
   loadData() {
-    this.api.getClients().subscribe(cs => (this.clients = cs));
+    this.clientService.getClients().subscribe(cs => (this.clients = cs));
     this.api.getProjects().subscribe(ps => (this.projects = ps));
     this.api.getUsers().subscribe(us => (this.users = us));
   }
 
   projectsByClient(clientId: number): Project[] {
     return this.projects.filter(p => p.client_id === clientId);
+  }
+
+  new() {
+    this.editing = null;
+    this.showForm = true;
+  }
+
+  edit(c: Client) {
+    this.editing = c;
+    this.showForm = true;
+  }
+
+  remove(c: Client) {
+    if (confirm('¿Eliminar cliente?')) {
+      this.clientService.deleteClient(c.id).subscribe(() => this.loadData());
+    }
+  }
+
+  onSaved() {
+    this.showForm = false;
+    this.loadData();
   }
 }

--- a/frontend/src/app/components/client-admin/client-form.component.ts
+++ b/frontend/src/app/components/client-admin/client-form.component.ts
@@ -1,0 +1,48 @@
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Client, ClientCreate } from '../../models';
+import { ClientService } from '../../services/client.service';
+
+@Component({
+  selector: 'app-client-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">{{ client ? 'Editar Cliente' : 'Nuevo Cliente' }}</h3>
+        <form (ngSubmit)="save()">
+          <div class="mb-3">
+            <label class="form-label">Nombre</label>
+            <input class="form-control" [(ngModel)]="form.name" name="name" required>
+          </div>
+          <button class="btn btn-primary" type="submit">Guardar</button>
+          <button type="button" class="btn btn-secondary ms-2" (click)="cancel.emit()">Cancelar</button>
+        </form>
+      </div>
+    </div>
+  `
+})
+export class ClientFormComponent implements OnInit {
+  @Input() client: Client | null = null;
+  @Output() saved = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  form: ClientCreate = { name: '' };
+
+  constructor(private service: ClientService) {}
+
+  ngOnInit() {
+    if (this.client) {
+      this.form = { name: this.client.name };
+    }
+  }
+
+  save() {
+    const obs = this.client
+      ? this.service.updateClient(this.client.id, this.form)
+      : this.service.createClient(this.form);
+    obs.subscribe(() => this.saved.emit());
+  }
+}

--- a/frontend/src/app/services/client.service.ts
+++ b/frontend/src/app/services/client.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { Client, ClientCreate } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class ClientService {
+  constructor(private api: ApiService) {}
+
+  getClients(): Observable<Client[]> {
+    return this.api.getClients();
+  }
+
+  createClient(client: ClientCreate): Observable<Client> {
+    return this.api.createClient(client);
+  }
+
+  updateClient(id: number, client: ClientCreate): Observable<Client> {
+    return this.api.updateClient(id, client);
+  }
+
+  deleteClient(id: number): Observable<any> {
+    return this.api.deleteClient(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ClientService` for API calls
- add `ClientFormComponent` for creating and editing clients
- update `ClientAdminComponent` to support creating, editing and deleting clients

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c26c45950832f8e66b379054712ce