### PR TITLE
Restrict user administration to admins

### DIFF
--- a/frontend/src/app/admin.guard.ts
+++ b/frontend/src/app/admin.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+import { of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export const adminGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+
+  if (!api.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  return api.getCurrentUser().pipe(
+    map(user =>
+      user.role?.name === 'Administrador'
+        ? true
+        : router.createUrlTree(['/dashboard'])
+    ),
+    catchError(() => of(router.createUrlTree(['/dashboard'])))
+  );
+};

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -16,7 +16,8 @@ export const routes: Routes = [
   },
   {
     path: 'users',
-    loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent)
+    loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent),
+    canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
   },
   {
     path: 'register',


### PR DESCRIPTION
## Summary
- ensure only admins can access user management

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c26e8d7dc832f8fe884a2027876a6