### PR TITLE
Add extra default users and update client role permissions

### DIFF
--- a/backend/README2.md
+++ b/backend/README2.md
@@ -42,6 +42,11 @@ Al iniciar la aplicación se crean automáticamente los roles:
 - Gerente de servicios
 
 También se genera el usuario inicial `admin` con la contraseña `admin` perteneciente al rol **Administrador**.
+Además, se crean tres usuarios predeterminados:
+
+- `architect` con rol **Arquitecto de Automatización** (contraseña `architect`)
+- `service_manager` con rol **Gerente de servicios** (contraseña `service_manager`)
+- `test_automator` con rol **Automatizador de Pruebas** (contraseña `test_automator`)
 
 Ahora cada rol puede tener permisos asociados a las páginas del frontend. Usa los siguientes endpoints para administrarlos:
 
@@ -51,7 +56,7 @@ Ahora cada rol puede tener permisos asociados a las páginas del frontend. Usa l
 
 ## Clientes y proyectos
 
-Los clientes y proyectos pueden gestionarse únicamente por usuarios con rol **Administrador**. Un cliente puede tener varios proyectos y ambos pueden inactivarse. Los analistas se asignan a los proyectos y solamente los analistas asignados (o los usuarios Administrador) pueden consultarlos.
+Los clientes pueden ser creados y actualizados por usuarios con rol **Administrador** o **Gerente de servicios**, mientras que la eliminación sigue reservada al **Administrador**. Un cliente puede tener varios proyectos y ambos pueden inactivarse. Los analistas se asignan a los proyectos y solamente los analistas asignados (o los usuarios Administrador) pueden consultarlos.
 
 Endpoints principales:
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,21 @@ def init_data():
             )
             db.add(admin)
             db.commit()
+
+        # create additional default users if they do not exist
+        defaults = {
+            "architect": "Arquitecto de Automatización",
+            "service_manager": "Gerente de servicios",
+            "test_automator": "Automatizador de Pruebas",
+        }
+        for username, role_name in defaults.items():
+            if not db.query(models.User).filter(models.User.username == username).first():
+                role = db.query(models.Role).filter(models.Role.name == role_name).first()
+                if role:
+                    hashed = deps.get_password_hash(username)
+                    user = models.User(username=username, hashed_password=hashed, role=role)
+                    db.add(user)
+        db.commit()
     finally:
         db.close()
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -203,7 +203,7 @@ def login_for_access_token(
 def create_client(
     client: schemas.ClientCreate,
     db: Session = Depends(deps.get_db),
-    current_user: models.User = deps.require_role(["Administrador"]),
+    current_user: models.User = deps.require_role(["Administrador", "Gerente de servicios"]),
 ):
     if db.query(models.Client).filter(models.Client.name == client.name).first():
         raise HTTPException(status_code=400, detail="Client already exists")
@@ -217,7 +217,7 @@ def create_client(
 @router.get("/clients/", response_model=list[schemas.Client])
 def read_clients(
     db: Session = Depends(deps.get_db),
-    current_user: models.User = deps.require_role(["Administrador"]),
+    current_user: models.User = deps.require_role(["Administrador", "Gerente de servicios"]),
 ):
     return db.query(models.Client).all()
 
@@ -227,7 +227,7 @@ def update_client(
     client_id: int,
     client: schemas.ClientCreate,
     db: Session = Depends(deps.get_db),
-    current_user: models.User = deps.require_role(["Administrador"]),
+    current_user: models.User = deps.require_role(["Administrador", "Gerente de servicios"]),
 ):
     db_client = db.query(models.Client).filter(models.Client.id == client_id).first()
     if db_client is None:


### PR DESCRIPTION
## Summary
- add creation of architect, service manager and test automator users
- allow service manager role to create and update clients
- document default users and new permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c286da03c832faf5de3881b72944c