### PR TITLE
Add metrics endpoint

### DIFF
--- a/backend/README2.md
+++ b/backend/README2.md
@@ -183,6 +183,14 @@ Endpoints principales:
 - `POST /executionplans/{id}/run` disparar la ejecución y registrar el estado inicial. Si el agente ya tiene una ejecución pendiente se rechaza la petición.
 - `GET /agents/{hostname}/pending` un agente autenticado consulta su próxima ejecución pendiente y recibe el plan, caso de prueba, elementos y acciones con parámetros
 
+### Métricas
+
+El rol **Arquitecto de Automatización** puede consultar un resumen general de clientes, proyectos, analistas asignados y flujos de pruebas.
+
+Endpoints principales:
+
+- `GET /metrics/overview` obtener el listado de clientes con sus proyectos y analistas junto con todos los flujos registrados
+
 ## Colección Postman
 
 Para facilitar las pruebas manuales o de integración se incluye el script

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1301,3 +1301,13 @@ def delete_test(test_id: int, db: Session = Depends(deps.get_db), current_user: 
     db.delete(test)
     db.commit()
     return {"ok": True}
+
+
+@router.get("/metrics/overview", response_model=schemas.Metrics)
+def get_metrics(
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = deps.require_role(["Administrador", "Arquitecto de Automatización"]),
+):
+    clients = db.query(models.Client).all()
+    flows = db.query(models.TestCase).all()
+    return schemas.Metrics(clients=clients, flows=flows)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -300,3 +300,12 @@ class PendingExecution(BaseModel):
     plan: ExecutionPlan
     test: Test
     assignments: list[AssignmentDetail]
+
+
+class ClientDetail(Client):
+    projects: List[Project] = []
+
+
+class Metrics(BaseModel):
+    clients: List[ClientDetail]
+    flows: List[Test]


### PR DESCRIPTION
## Summary
- expose `/metrics/overview` for automation architects
- document metrics endpoint
- add Metrics schema objects

## Testing
- `python -m py_compile backend/app/routes.py backend/app/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_684c316c9c94832f8766675f5aa64d59