### PR TITLE
Implement analyst assignment UI

### DIFF
--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -3,13 +3,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
 import { ClientService } from '../../services/client.service';
+import { ProjectService } from '../../services/project.service';
 import { Client, Project, User } from '../../models';
 import { ClientFormComponent } from './client-form.component';
+import { ProjectAnalystsComponent } from './project-analysts.component';
 
 @Component({
   selector: 'app-client-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, ClientFormComponent],
+  imports: [CommonModule, FormsModule, ClientFormComponent, ProjectAnalystsComponent],
   template: `
     <div class="main-panel">
       <h1>Administración de Clientes</h1>
@@ -26,11 +28,13 @@ import { ClientFormComponent } from './client-form.component';
             <span *ngFor="let a of p.analysts; let i = index">
               {{ a.username }}<span *ngIf="i < p.analysts.length - 1">, </span>
             </span>
+            <button class="btn btn-sm btn-info ms-2" (click)="manageAnalysts(p)">Analistas</button>
           </li>
         </ul>
       </div>
 
       <app-client-form *ngIf="showForm" [client]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-client-form>
+      <app-project-analysts *ngIf="selectedProject" [projectId]="selectedProject.id" (updated)="loadData()" (close)="selectedProject=null"></app-project-analysts>
     </div>
   `
 })
@@ -40,8 +44,13 @@ export class ClientAdminComponent implements OnInit {
   users: User[] = [];
   showForm = false;
   editing: Client | null = null;
+  selectedProject: Project | null = null;
 
-  constructor(private api: ApiService, private clientService: ClientService) {}
+  constructor(
+    private api: ApiService,
+    private clientService: ClientService,
+    private projectService: ProjectService
+  ) {}
 
   ngOnInit() {
     this.loadData();
@@ -49,7 +58,7 @@ export class ClientAdminComponent implements OnInit {
 
   loadData() {
     this.clientService.getClients().subscribe(cs => (this.clients = cs));
-    this.api.getProjects().subscribe(ps => (this.projects = ps));
+    this.projectService.getProjects().subscribe(ps => (this.projects = ps));
     this.api.getUsers().subscribe(us => (this.users = us));
   }
 
@@ -71,6 +80,10 @@ export class ClientAdminComponent implements OnInit {
     if (confirm('¿Eliminar cliente?')) {
       this.clientService.deleteClient(c.id).subscribe(() => this.loadData());
     }
+  }
+
+  manageAnalysts(p: Project) {
+    this.selectedProject = p;
   }
 
   onSaved() {

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { User, Project } from '../../models';
+import { ProjectService } from '../../services/project.service';
+import { ApiService } from '../../services/api.service';
+
+@Component({
+  selector: 'app-project-analysts',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="card" *ngIf="project">
+      <div class="card-body">
+        <h3 class="card-title">Analistas de {{ project.name }}</h3>
+        <div *ngFor="let u of analysts" class="form-check">
+          <input class="form-check-input" type="checkbox" [id]="'an-'+u.id"
+            [checked]="isAssigned(u)" (change)="toggle(u, $event.target.checked)">
+          <label class="form-check-label" [for]="'an-'+u.id">
+            {{ u.username }} ({{ u.role.name }})
+          </label>
+        </div>
+        <button class="btn btn-secondary mt-3" (click)="close.emit()">Cerrar</button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .form-check { margin-bottom: 0.5rem; }
+  `]
+})
+export class ProjectAnalystsComponent implements OnChanges {
+  @Input() projectId!: number;
+  @Output() updated = new EventEmitter<void>();
+  @Output() close = new EventEmitter<void>();
+
+  project: Project | null = null;
+  analysts: User[] = [];
+
+  constructor(private projectService: ProjectService, private api: ApiService) {}
+
+  ngOnChanges() {
+    if (this.projectId) {
+      this.load();
+    }
+  }
+
+  load() {
+    this.projectService.getProject(this.projectId).subscribe(p => this.project = p);
+    this.api.getUsers().subscribe(users => {
+      this.analysts = users.filter(u =>
+        u.role.name === 'Analista de Pruebas con skill de automatización' ||
+        u.role.name === 'Automatizador de Pruebas'
+      );
+    });
+  }
+
+  isAssigned(u: User): boolean {
+    return this.project?.analysts.some(a => a.id === u.id) ?? false;
+  }
+
+  toggle(user: User, checked: boolean) {
+    if (!this.project) return;
+    const obs = checked ?
+      this.projectService.assignAnalyst(this.project.id, user.id) :
+      this.projectService.unassignAnalyst(this.project.id, user.id);
+    obs.subscribe(p => {
+      this.project = p;
+      this.updated.emit();
+    });
+  }
+}

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { Project, ProjectCreate } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class ProjectService {
+  constructor(private api: ApiService) {}
+
+  getProjects(): Observable<Project[]> {
+    return this.api.getProjects();
+  }
+
+  getProject(id: number): Observable<Project> {
+    return this.api.getProject(id);
+  }
+
+  createProject(project: ProjectCreate): Observable<Project> {
+    return this.api.createProject(project);
+  }
+
+  updateProject(id: number, project: ProjectCreate): Observable<Project> {
+    return this.api.updateProject(id, project);
+  }
+
+  deleteProject(id: number): Observable<any> {
+    return this.api.deleteProject(id);
+  }
+
+  assignAnalyst(projectId: number, userId: number): Observable<Project> {
+    return this.api.assignAnalyst(projectId, userId);
+  }
+
+  unassignAnalyst(projectId: number, userId: number): Observable<Project> {
+    return this.api.unassignAnalyst(projectId, userId);
+  }
+}


### PR DESCRIPTION
## Summary
- add `ProjectService` to wrap project APIs
- add `ProjectAnalystsComponent` for assigning analysts to a project
- extend client admin view with button to manage project analysts

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35309030832f88a185d4253bff04