### PR TITLE
Add analyst assignment to clients

### DIFF
--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -7,11 +7,12 @@ import { ProjectService } from '../../services/project.service';
 import { Client, Project, User } from '../../models';
 import { ClientFormComponent } from './client-form.component';
 import { ProjectAnalystsComponent } from './project-analysts.component';
+import { ClientAnalystsComponent } from './client-analysts.component';
 
 @Component({
   selector: 'app-client-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, ClientFormComponent, ProjectAnalystsComponent],
+  imports: [CommonModule, FormsModule, ClientFormComponent, ProjectAnalystsComponent, ClientAnalystsComponent],
   template: `
     <div class="main-panel">
       <h1>Administración de Clientes</h1>
@@ -21,6 +22,7 @@ import { ProjectAnalystsComponent } from './project-analysts.component';
           {{ c.name }}
           <button class="btn btn-sm btn-secondary ms-2" (click)="edit(c)">Editar</button>
           <button class="btn btn-sm btn-danger ms-2" (click)="remove(c)">Eliminar</button>
+          <button class="btn btn-sm btn-info ms-2" (click)="manageClientAnalysts(c)">Analistas</button>
         </h3>
         <ul class="list-group">
           <li class="list-group-item" *ngFor="let p of projectsByClient(c.id)">
@@ -35,6 +37,7 @@ import { ProjectAnalystsComponent } from './project-analysts.component';
 
       <app-client-form *ngIf="showForm" [client]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-client-form>
       <app-project-analysts *ngIf="selectedProject" [projectId]="selectedProject.id" (updated)="loadData()" (close)="selectedProject=null"></app-project-analysts>
+      <app-client-analysts *ngIf="selectedClient" [clientId]="selectedClient.id" (updated)="loadData()" (close)="selectedClient=null"></app-client-analysts>
     </div>
   `
 })
@@ -45,6 +48,7 @@ export class ClientAdminComponent implements OnInit {
   showForm = false;
   editing: Client | null = null;
   selectedProject: Project | null = null;
+  selectedClient: Client | null = null;
 
   constructor(
     private api: ApiService,
@@ -80,6 +84,10 @@ export class ClientAdminComponent implements OnInit {
     if (confirm('¿Eliminar cliente?')) {
       this.clientService.deleteClient(c.id).subscribe(() => this.loadData());
     }
+  }
+
+  manageClientAnalysts(c: Client) {
+    this.selectedClient = c;
   }
 
   manageAnalysts(p: Project) {

--- a/frontend/src/app/components/client-admin/client-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/client-analysts.component.ts
@@ -1,0 +1,74 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { User, Client } from '../../models';
+import { ClientService } from '../../services/client.service';
+import { ApiService } from '../../services/api.service';
+
+@Component({
+  selector: 'app-client-analysts',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="card" *ngIf="client">
+      <div class="card-body">
+        <h3 class="card-title">Analistas de {{ client.name }}</h3>
+        <div *ngFor="let u of analysts" class="form-check">
+          <input class="form-check-input" type="checkbox" [id]="'ca-'+u.id"
+            [checked]="isAssigned(u)"
+            (change)="toggle(u, ($event.target as HTMLInputElement).checked)">
+          <label class="form-check-label" [for]="'ca-'+u.id">
+            {{ u.username }} ({{ u.role.name }})
+          </label>
+        </div>
+        <button class="btn btn-secondary mt-3" (click)="close.emit()">Cerrar</button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .form-check { margin-bottom: 0.5rem; }
+  `]
+})
+export class ClientAnalystsComponent implements OnChanges {
+  @Input() clientId!: number;
+  @Output() updated = new EventEmitter<void>();
+  @Output() close = new EventEmitter<void>();
+
+  client: Client | null = null;
+  analysts: User[] = [];
+
+  constructor(private clientService: ClientService, private api: ApiService) {}
+
+  ngOnChanges() {
+    if (this.clientId) {
+      this.load();
+    }
+  }
+
+  load() {
+    this.clientService.getClients().subscribe(cs => {
+      this.client = cs.find(c => c.id === this.clientId) || null;
+    });
+    this.api.getUsers().subscribe(users => {
+      this.analysts = users.filter(u =>
+        u.role.name === 'Analista de Pruebas con skill de automatización' ||
+        u.role.name === 'Automatizador de Pruebas'
+      );
+    });
+  }
+
+  isAssigned(u: User): boolean {
+    return this.client?.analysts.some(a => a.id === u.id) ?? false;
+  }
+
+  toggle(user: User, checked: boolean) {
+    if (!this.client) return;
+    const obs = checked
+      ? this.clientService.assignAnalyst(this.client.id, user.id)
+      : this.clientService.unassignAnalyst(this.client.id, user.id);
+    obs.subscribe(c => {
+      this.client = c;
+      this.updated.emit();
+    });
+  }
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -108,6 +108,18 @@ export class ApiService {
     return this.http.delete(`${this.baseUrl}/clients/${id}`, { headers: this.getHeaders() });
   }
 
+  assignClientAnalyst(clientId: number, userId: number, dedication?: number): Observable<Client> {
+    let url = `${this.baseUrl}/clients/${clientId}/analysts/${userId}`;
+    if (dedication !== undefined) {
+      url += `?dedication=${dedication}`;
+    }
+    return this.http.post<Client>(url, {}, { headers: this.getHeaders() });
+  }
+
+  unassignClientAnalyst(clientId: number, userId: number): Observable<Client> {
+    return this.http.delete<Client>(`${this.baseUrl}/clients/${clientId}/analysts/${userId}`, { headers: this.getHeaders() });
+  }
+
   // Proyectos
   getProjects(): Observable<Project[]> {
     return this.http.get<Project[]>(`${this.baseUrl}/projects/`, { headers: this.getHeaders() });

--- a/frontend/src/app/services/client.service.ts
+++ b/frontend/src/app/services/client.service.ts
@@ -22,4 +22,12 @@ export class ClientService {
   deleteClient(id: number): Observable<any> {
     return this.api.deleteClient(id);
   }
+
+  assignAnalyst(clientId: number, userId: number, dedication?: number): Observable<Client> {
+    return this.api.assignClientAnalyst(clientId, userId, dedication);
+  }
+
+  unassignAnalyst(clientId: number, userId: number): Observable<Client> {
+    return this.api.unassignClientAnalyst(clientId, userId);
+  }
 }


### PR DESCRIPTION
## Summary
- enable analyst assignment management on the client admin page
- implement new `ClientAnalystsComponent`
- expose API methods for assigning/unassigning client analysts
- extend `ClientService` with matching methods

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c390e3b2c832f8226a6b6333a1d64