### PR TITLE
Add analysts endpoint and use it in admin views

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -133,6 +133,23 @@ def read_users(db: Session = Depends(deps.get_db), current_user: models.User = d
     return db.query(models.User).all()
 
 
+@router.get("/analysts/", response_model=list[schemas.User])
+def read_analysts(
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = deps.require_role(["Administrador", "Gerente de servicios"]),
+):
+    analyst_roles = [
+        "Analista de Pruebas con skill de automatización",
+        "Automatizador de Pruebas",
+    ]
+    return (
+        db.query(models.User)
+        .join(models.Role)
+        .filter(models.Role.name.in_(analyst_roles))
+        .all()
+    )
+
+
 @router.get("/users/{user_id}", response_model=schemas.User)
 def read_user(user_id: int, db: Session = Depends(deps.get_db), current_user: models.User = deps.require_role(["Administrador"])):
     user = db.query(models.User).filter(models.User.id == user_id).first()

--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
 import { ClientService } from '../../services/client.service';
 import { ProjectService } from '../../services/project.service';
-import { Client, Project, User } from '../../models';
+import { Client, Project } from '../../models';
 import { ClientFormComponent } from './client-form.component';
 import { ProjectAnalystsComponent } from './project-analysts.component';
 import { ClientAnalystsComponent } from './client-analysts.component';
@@ -45,7 +45,6 @@ import { ClientAnalystsComponent } from './client-analysts.component';
 export class ClientAdminComponent implements OnInit {
   clients: Client[] = [];
   projects: Project[] = [];
-  users: User[] = [];
   showForm = false;
   editing: Client | null = null;
   selectedProject: Project | null = null;
@@ -64,7 +63,6 @@ export class ClientAdminComponent implements OnInit {
   loadData() {
     this.clientService.getClients().subscribe(cs => (this.clients = cs));
     this.projectService.getProjects().subscribe(ps => (this.projects = ps));
-    this.api.getUsers().subscribe(us => (this.users = us));
   }
 
   projectsByClient(clientId: number): Project[] {

--- a/frontend/src/app/components/client-admin/client-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/client-analysts.component.ts
@@ -49,11 +49,8 @@ export class ClientAnalystsComponent implements OnChanges {
     this.clientService.getClients().subscribe(cs => {
       this.client = cs.find(c => c.id === this.clientId) || null;
     });
-    this.api.getUsers().subscribe(users => {
-      this.analysts = users.filter(u =>
-        u.role.name === 'Analista de Pruebas con skill de automatización' ||
-        u.role.name === 'Automatizador de Pruebas'
-      );
+    this.api.getAnalysts().subscribe(users => {
+      this.analysts = users;
     });
   }
 

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -47,11 +47,8 @@ export class ProjectAnalystsComponent implements OnChanges {
 
   load() {
     this.projectService.getProject(this.projectId).subscribe(p => this.project = p);
-    this.api.getUsers().subscribe(users => {
-      this.analysts = users.filter(u =>
-        u.role.name === 'Analista de Pruebas con skill de automatización' ||
-        u.role.name === 'Automatizador de Pruebas'
-      );
+    this.api.getAnalysts().subscribe(users => {
+      this.analysts = users;
     });
   }
 

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -87,6 +87,10 @@ export class ApiService {
     return this.http.get<User[]>(`${this.baseUrl}/users/`, { headers: this.getHeaders() });
   }
 
+  getAnalysts(): Observable<User[]> {
+    return this.http.get<User[]>(`${this.baseUrl}/analysts/`, { headers: this.getHeaders() });
+  }
+
   getUser(id: number): Observable<User> {
     return this.http.get<User>(`${this.baseUrl}/users/${id}`, { headers: this.getHeaders() });
   }


### PR DESCRIPTION
## Summary
- create new backend route `/analysts/` for service managers
- add `getAnalysts` helper in ApiService
- update analyst management components to call the new endpoint
- remove unused user list call from client-admin

## Testing
- `pylint $(git ls-files '*.py')` *(fails: line-too-long and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68546dc7c234832f90ce587c3821ab5f