### PR TITLE
Add analysts search and paging

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -133,6 +133,31 @@ def read_users(db: Session = Depends(deps.get_db), current_user: models.User = d
     return db.query(models.User).all()
 
 
+@router.get("/analysts/", response_model=list[schemas.User])
+def read_analysts(
+    search: str | None = None,
+    skip: int = 0,
+    limit: int = 10,
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = deps.require_role([
+        "Administrador",
+        "Gerente de servicios",
+    ]),
+):
+    analyst_roles = [
+        "Analista de Pruebas con skill de automatización",
+        "Automatizador de Pruebas",
+    ]
+    query = (
+        db.query(models.User)
+        .join(models.Role)
+        .filter(models.Role.name.in_(analyst_roles))
+    )
+    if search:
+        query = query.filter(models.User.username.ilike(f"%{search}%"))
+    return query.offset(skip).limit(limit).all()
+
+
 @router.get("/users/{user_id}", response_model=schemas.User)
 def read_user(user_id: int, db: Session = Depends(deps.get_db), current_user: models.User = deps.require_role(["Administrador"])):
     user = db.query(models.User).filter(models.User.id == user_id).first()

--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
 import { ClientService } from '../../services/client.service';
 import { ProjectService } from '../../services/project.service';
-import { Client, Project, User } from '../../models';
+import { Client, Project } from '../../models';
 import { ClientFormComponent } from './client-form.component';
 import { ProjectAnalystsComponent } from './project-analysts.component';
 import { ClientAnalystsComponent } from './client-analysts.component';
@@ -45,7 +45,6 @@ import { ClientAnalystsComponent } from './client-analysts.component';
 export class ClientAdminComponent implements OnInit {
   clients: Client[] = [];
   projects: Project[] = [];
-  users: User[] = [];
   showForm = false;
   editing: Client | null = null;
   selectedProject: Project | null = null;
@@ -64,7 +63,6 @@ export class ClientAdminComponent implements OnInit {
   loadData() {
     this.clientService.getClients().subscribe(cs => (this.clients = cs));
     this.projectService.getProjects().subscribe(ps => (this.projects = ps));
-    this.api.getUsers().subscribe(us => (this.users = us));
   }
 
   projectsByClient(clientId: number): Project[] {

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -13,6 +13,7 @@ import { ApiService } from '../../services/api.service';
     <div class="card" *ngIf="project">
       <div class="card-body">
         <h3 class="card-title">Analistas de {{ project.name }}</h3>
+        <input class="form-control mb-2" placeholder="Buscar..." [(ngModel)]="search" (ngModelChange)="onSearch()" />
         <div *ngFor="let u of analysts" class="form-check">
           <input class="form-check-input" type="checkbox" [id]="'an-'+u.id"
             [checked]="isAssigned(u)"
@@ -21,6 +22,17 @@ import { ApiService } from '../../services/api.service';
             {{ u.username }} ({{ u.role.name }})
           </label>
         </div>
+        <nav class="mt-2">
+          <ul class="pagination mb-0">
+            <li class="page-item" [class.disabled]="page === 1">
+              <button class="page-link" (click)="prev()">Anterior</button>
+            </li>
+            <li class="page-item"><span class="page-link">{{ page }}</span></li>
+            <li class="page-item" [class.disabled]="analysts.length < 10">
+              <button class="page-link" (click)="next()" [disabled]="analysts.length < 10">Siguiente</button>
+            </li>
+          </ul>
+        </nav>
         <button class="btn btn-secondary mt-3" (click)="close.emit()">Cerrar</button>
       </div>
     </div>
@@ -36,6 +48,8 @@ export class ProjectAnalystsComponent implements OnChanges {
 
   project: Project | null = null;
   analysts: User[] = [];
+  page = 1;
+  search = '';
 
   constructor(private projectService: ProjectService, private api: ApiService) {}
 
@@ -47,12 +61,28 @@ export class ProjectAnalystsComponent implements OnChanges {
 
   load() {
     this.projectService.getProject(this.projectId).subscribe(p => this.project = p);
-    this.api.getUsers().subscribe(users => {
-      this.analysts = users.filter(u =>
-        u.role.name === 'Analista de Pruebas con skill de automatización' ||
-        u.role.name === 'Automatizador de Pruebas'
-      );
+    this.api.getAnalysts(this.search, this.page).subscribe(users => {
+      this.analysts = users;
     });
+  }
+
+  onSearch() {
+    this.page = 1;
+    this.load();
+  }
+
+  prev() {
+    if (this.page > 1) {
+      this.page--;
+      this.load();
+    }
+  }
+
+  next() {
+    if (this.analysts.length === 10) {
+      this.page++;
+      this.load();
+    }
   }
 
   isAssigned(u: User): boolean {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -87,6 +87,17 @@ export class ApiService {
     return this.http.get<User[]>(`${this.baseUrl}/users/`, { headers: this.getHeaders() });
   }
 
+  getAnalysts(search?: string, page = 1): Observable<User[]> {
+    const params: string[] = [];
+    if (search) {
+      params.push(`search=${encodeURIComponent(search)}`);
+    }
+    params.push(`skip=${(page - 1) * 10}`);
+    params.push('limit=10');
+    const query = params.length ? `?${params.join('&')}` : '';
+    return this.http.get<User[]>(`${this.baseUrl}/analysts/${query}`, { headers: this.getHeaders() });
+  }
+
   getUser(id: number): Observable<User> {
     return this.http.get<User>(`${this.baseUrl}/users/${id}`, { headers: this.getHeaders() });
   }


### PR DESCRIPTION
## Summary
- extend `/analysts/` endpoint with `search`, `skip`, `limit`
- add pagination and search bar to analyst management components
- update ApiService `getAnalysts` helper to accept search and page

## Testing
- `pylint $(git ls-files '*.py')` *(fails: line-too-long and other existing issues)*
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546dc7c234832f90ce587c3821ab5f