### PR TITLE
Add client admin filters and history

### DIFF
--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
 import { ClientService } from '../../services/client.service';
 import { ProjectService } from '../../services/project.service';
-import { Client, Project } from '../../models';
+import { Client, Project, User } from '../../models';
 import { ClientFormComponent } from './client-form.component';
 import { ProjectAnalystsComponent } from './project-analysts.component';
 import { ClientAnalystsComponent } from './client-analysts.component';
@@ -17,12 +17,25 @@ import { ClientAnalystsComponent } from './client-analysts.component';
   template: `
     <div class="main-panel">
       <h1>Administración de Clientes</h1>
-      <button class="btn btn-primary mb-3" (click)="new()">Nuevo Cliente</button>
-      <div *ngFor="let c of clients" class="mb-4">
+      <input class="form-control mb-2" placeholder="Buscar..." [(ngModel)]="search" />
+      <ul class="nav nav-tabs mb-3">
+        <li class="nav-item">
+          <a class="nav-link" [class.active]="tab==='active'" (click)="tab='active'">Activos</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" [class.active]="tab==='inactive'" (click)="tab='inactive'">Inactivos</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" [class.active]="tab==='history'" (click)="tab='history'">Historial</a>
+        </li>
+      </ul>
+      <div *ngIf="tab!=='history'">
+        <button class="btn btn-primary mb-3" (click)="new()">Nuevo Cliente</button>
+        <div *ngFor="let c of filteredClients()" class="mb-4">
         <h3>
           {{ c.name }}
           <button class="btn btn-sm btn-secondary ms-2" (click)="edit(c)">Editar</button>
-          <button class="btn btn-sm btn-danger ms-2" (click)="remove(c)">Eliminar</button>
+          <button class="btn btn-sm btn-danger ms-2" (click)="remove(c)">Inactivar</button>
           <button class="btn btn-sm btn-info ms-2" (click)="manageClientAnalysts(c)">Analistas</button>
         </h3>
         <ul class="list-group">
@@ -34,12 +47,17 @@ import { ClientAnalystsComponent } from './client-analysts.component';
             <button class="btn btn-sm btn-info ms-2" (click)="manageAnalysts(p)">Analistas</button>
           </li>
         </ul>
+        </div>
+      </div>
+      <div *ngIf="tab==='history'">
+        <ul class="list-group">
+          <li class="list-group-item" *ngFor="let h of history">{{ h.client }} - {{ h.action }}</li>
+        </ul>
       </div>
 
-      <app-client-form *ngIf="showForm" [client]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-client-form>
-      <app-project-analysts *ngIf="selectedProject" [projectId]="selectedProject.id" (updated)="loadData()" (close)="selectedProject=null"></app-project-analysts>
-      <app-client-analysts *ngIf="selectedClient" [clientId]="selectedClient.id" (updated)="loadData()" (close)="selectedClient=null"></app-client-analysts>
-    </div>
+      <app-client-form *ngIf="showForm" [client]="editing" (saved)="onSaved($event)" (cancel)="showForm=false"></app-client-form>
+      <app-project-analysts *ngIf="selectedProject" [projectId]="selectedProject.id" (updated)="onProjectAnalystsUpdated($event)" (close)="selectedProject=null"></app-project-analysts>
+      <app-client-analysts *ngIf="selectedClient" [clientId]="selectedClient.id" (updated)="onClientAnalystsUpdated($event)" (close)="selectedClient=null"></app-client-analysts>
   `
 })
 export class ClientAdminComponent implements OnInit {
@@ -49,6 +67,9 @@ export class ClientAdminComponent implements OnInit {
   editing: Client | null = null;
   selectedProject: Project | null = null;
   selectedClient: Client | null = null;
+  search = '';
+  tab: 'active' | 'inactive' | 'history' = 'active';
+  history: { client: string; action: string }[] = [];
 
   constructor(
     private api: ApiService,
@@ -63,6 +84,19 @@ export class ClientAdminComponent implements OnInit {
   loadData() {
     this.clientService.getClients().subscribe(cs => (this.clients = cs));
     this.projectService.getProjects().subscribe(ps => (this.projects = ps));
+  }
+
+  filteredClients(): Client[] {
+    const term = this.search.toLowerCase();
+    return this.clients
+      .filter(c => c.name.toLowerCase().includes(term))
+      .filter(c =>
+        this.tab === 'active'
+          ? c.is_active
+          : this.tab === 'inactive'
+          ? !c.is_active
+          : true
+      );
   }
 
   projectsByClient(clientId: number): Project[] {
@@ -80,8 +114,11 @@ export class ClientAdminComponent implements OnInit {
   }
 
   remove(c: Client) {
-    if (confirm('¿Eliminar cliente?')) {
-      this.clientService.deleteClient(c.id).subscribe(() => this.loadData());
+    if (confirm('¿Inactivar cliente?')) {
+      this.clientService.deleteClient(c.id).subscribe(() => {
+        this.history.push({ client: c.name, action: 'inactivado' });
+        this.loadData();
+      });
     }
   }
 
@@ -93,8 +130,25 @@ export class ClientAdminComponent implements OnInit {
     this.selectedClient = c;
   }
 
-  onSaved() {
+  onProjectAnalystsUpdated(e: { action: string; user: User }) {
+    if (this.selectedProject) {
+      const clientName = this.clients.find(cl => cl.id === this.selectedProject!.client_id)?.name || '';
+      this.history.push({ client: clientName, action: `${e.action} (${e.user.username}) en proyecto ${this.selectedProject.name}` });
+      this.loadData();
+    }
+  }
+
+  onClientAnalystsUpdated(e: { action: string; user: User }) {
+    if (this.selectedClient) {
+      this.history.push({ client: this.selectedClient.name, action: `${e.action} (${e.user.username})` });
+      this.loadData();
+    }
+  }
+
+  onSaved(c: Client) {
     this.showForm = false;
     this.loadData();
+    const action = this.editing ? 'actualizado' : 'creado';
+    this.history.push({ client: c.name, action });
   }
 }

--- a/frontend/src/app/components/client-admin/client-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/client-analysts.component.ts
@@ -43,7 +43,7 @@ import { ApiService } from '../../services/api.service';
 })
 export class ClientAnalystsComponent implements OnChanges {
   @Input() clientId!: number;
-  @Output() updated = new EventEmitter<void>();
+  @Output() updated = new EventEmitter<{ action: string; user: User }>();
   @Output() close = new EventEmitter<void>();
 
   client: Client | null = null;
@@ -99,7 +99,8 @@ export class ClientAnalystsComponent implements OnChanges {
       : this.clientService.unassignAnalyst(this.client.id, user.id);
     obs.subscribe(c => {
       this.client = c;
-      this.updated.emit();
+      const action = checked ? 'added analyst' : 'removed analyst';
+      this.updated.emit({ action, user });
     });
   }
 }

--- a/frontend/src/app/components/client-admin/client-form.component.ts
+++ b/frontend/src/app/components/client-admin/client-form.component.ts
@@ -26,7 +26,7 @@ import { ClientService } from '../../services/client.service';
 })
 export class ClientFormComponent implements OnInit {
   @Input() client: Client | null = null;
-  @Output() saved = new EventEmitter<void>();
+  @Output() saved = new EventEmitter<Client>();
   @Output() cancel = new EventEmitter<void>();
 
   form: ClientCreate = { name: '' };
@@ -43,6 +43,6 @@ export class ClientFormComponent implements OnInit {
     const obs = this.client
       ? this.service.updateClient(this.client.id, this.form)
       : this.service.createClient(this.form);
-    obs.subscribe(() => this.saved.emit());
+    obs.subscribe(c => this.saved.emit(c));
   }
 }

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -43,7 +43,7 @@ import { ApiService } from '../../services/api.service';
 })
 export class ProjectAnalystsComponent implements OnChanges {
   @Input() projectId!: number;
-  @Output() updated = new EventEmitter<void>();
+  @Output() updated = new EventEmitter<{ action: string; user: User }>();
   @Output() close = new EventEmitter<void>();
 
   project: Project | null = null;
@@ -98,7 +98,8 @@ export class ProjectAnalystsComponent implements OnChanges {
       this.projectService.unassignAnalyst(this.project.id, user.id);
     obs.subscribe(p => {
       this.project = p;
-      this.updated.emit();
+      const action = checked ? 'added analyst' : 'removed analyst';
+      this.updated.emit({ action, user });
     });
   }
 }


### PR DESCRIPTION
## Summary
- add search bar and tabs to client admin UI
- log client actions like create, update, inactivate and analyst assignments
- emit detailed events from analyst components

## Testing
- `npm install`
- `npm test --silent` *(fails: TS18003 No inputs were found)*

------
https://chatgpt.com/codex/tasks/task_e_6854709c729c832f9115395ec403e9fa