### PR TITLE
Improve register/login handling

### DIFF
--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -42,26 +42,24 @@ import { LoginRequest } from '../../models';
               required>
           </div>
           
-          <div class="form-group" *ngIf="errorMessage">
-            <div class="alert alert-error">
-              {{ errorMessage }}
-            </div>
-          </div>
-          
-          <button 
-            type="submit" 
+          <button
+            type="submit"
             class="btn-primary login-btn"
             [disabled]="isLoading">
             <span *ngIf="isLoading">Iniciando sesión...</span>
             <span *ngIf="!isLoading">Iniciar Sesión</span>
           </button>
         </form>
-        
+
         <div class="login-footer">
           <p class="text-secondary">
             Usuario por defecto: <strong>admin</strong><br>
             Contraseña: <strong>admin</strong>
           </p>
+          <button type="button" class="btn-link register-btn" (click)="router.navigate(['/register'])">Crear cuenta</button>
+        </div>
+        <div *ngIf="errorMessage" class="alert alert-error alert-fixed">
+          {{ errorMessage }}
         </div>
       </div>
     </div>
@@ -131,11 +129,25 @@ import { LoginRequest } from '../../models';
       margin-top: 2rem;
       padding-top: 1rem;
       border-top: 1px solid var(--border-color);
-      
+
       p {
         font-size: 0.9rem;
         line-height: 1.5;
       }
+      .register-btn {
+        margin-top: 1rem;
+        background: none;
+        border: none;
+        color: var(--btn-primary);
+        cursor: pointer;
+      }
+    }
+
+    .alert-fixed {
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      z-index: 1000;
     }
   `]
 })

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -2,39 +2,186 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { UserCreate } from '../../models';
+import { UserCreate, LoginRequest } from '../../models';
 import { UserService } from '../../services/user.service';
+import { ApiService } from '../../services/api.service';
 
 @Component({
   selector: 'app-register',
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
-    <div class="main-panel">
-      <h1>Registrar Usuario</h1>
-      <form (ngSubmit)="save()" class="form">
-        <div class="mb-3">
-          <label class="form-label">Usuario</label>
-          <input class="form-control" [(ngModel)]="form.username" name="username" required>
+    <div class="login-container">
+      <div class="login-panel">
+        <div class="login-header">
+          <h1>Crear Cuenta</h1>
+          <p class="text-secondary">Sistema de Automatización</p>
         </div>
-        <div class="mb-3">
-          <label class="form-label">Contraseña</label>
-          <input class="form-control" type="password" [(ngModel)]="form.password" name="password" required>
+
+        <form (ngSubmit)="save()" class="login-form">
+          <div class="form-group">
+            <label>Usuario</label>
+            <input class="form-control" [(ngModel)]="form.username" name="username" required>
+          </div>
+          <div class="form-group">
+            <label>Contraseña</label>
+            <input type="password" class="form-control" [(ngModel)]="form.password" name="password" required>
+          </div>
+
+          <button type="submit" class="btn-primary login-btn" [disabled]="isLoading">
+            <span *ngIf="isLoading">Creando...</span>
+            <span *ngIf="!isLoading">Registrarse</span>
+          </button>
+        </form>
+
+        <div class="login-footer">
+          <button type="button" class="btn-link register-btn" (click)="router.navigate(['/login'])">Ya tengo cuenta</button>
         </div>
-        <button class="btn btn-primary" type="submit">Crear</button>
-        <button class="btn btn-secondary ms-2" type="button" (click)="router.navigate(['/users'])">Cancelar</button>
-      </form>
+
+        <div *ngIf="errorMessage" class="alert alert-error alert-fixed">
+          {{ errorMessage }}
+        </div>
+      </div>
     </div>
-  `
+  `,
+  styles: [`
+    .login-container {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .login-panel {
+      background: var(--panel-bg);
+      border-radius: 12px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+      padding: 3rem;
+      width: 100%;
+      max-width: 400px;
+      animation: panelEntrance 0.6s ease-out;
+    }
+
+    .login-header {
+      text-align: center;
+      margin-bottom: 2rem;
+
+      h1 {
+        color: var(--title-color);
+        margin-bottom: 0.5rem;
+        font-size: 2rem;
+      }
+    }
+
+    .form-group {
+      margin-bottom: 1.5rem;
+
+      label {
+        display: block;
+        margin-bottom: 0.5rem;
+        color: var(--subtitle-color);
+        font-weight: 500;
+      }
+    }
+
+    .login-btn {
+      width: 100%;
+      padding: 1rem;
+      font-size: 1.1rem;
+      margin-top: 1rem;
+    }
+
+    .alert {
+      padding: 0.75rem;
+      border-radius: 6px;
+      margin-bottom: 1rem;
+
+      &.alert-error {
+        background: #f8d7da;
+        color: #721c24;
+        border: 1px solid #f5c6cb;
+      }
+    }
+
+    .login-footer {
+      text-align: center;
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border-color);
+
+      .register-btn {
+        margin-top: 1rem;
+        background: none;
+        border: none;
+        color: var(--btn-primary);
+        cursor: pointer;
+      }
+    }
+
+    .alert-fixed {
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      z-index: 1000;
+    }
+  `]
 })
 export class RegisterComponent {
   form: UserCreate = { username: '', password: '' };
+  isLoading = false;
+  errorMessage = '';
 
-  constructor(private service: UserService, public router: Router) {}
+  constructor(
+    private service: UserService,
+    private api: ApiService,
+    public router: Router
+  ) {}
 
   save() {
-    this.service.createUser(this.form).subscribe(() => {
-      this.router.navigate(['/users']);
+    if (!this.form.username || !this.form.password) {
+      this.errorMessage = 'Usuario y contraseña requeridos';
+      return;
+    }
+
+    this.isLoading = true;
+    this.errorMessage = '';
+    this.service.createUser(this.form).subscribe({
+      next: () => {
+        const creds: LoginRequest = { username: this.form.username, password: this.form.password };
+        this.api.login(creds).subscribe({
+          next: () => {
+            this.api.getCurrentUser().subscribe({
+              next: (user) => {
+                const role = user.role?.name || '';
+                this.isLoading = false;
+                if (role === 'Administrador') {
+                  this.router.navigate(['/users']);
+                } else if (role === 'Arquitecto de Automatización' || role === 'Automation Engineer') {
+                  this.router.navigate(['/actions']);
+                } else if (role === 'Gerente de servicios') {
+                  this.router.navigate(['/client-admin']);
+                } else {
+                  this.router.navigate(['/dashboard']);
+                }
+              },
+              error: () => {
+                this.isLoading = false;
+                this.router.navigate(['/dashboard']);
+              }
+            });
+          },
+          error: () => {
+            this.isLoading = false;
+            this.errorMessage = 'Error al iniciar sesión';
+          }
+        });
+      },
+      error: (err) => {
+        this.isLoading = false;
+        this.errorMessage = 'Nombre de usuario en uso o contraseña insegura';
+        console.error('Register error:', err);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- make login errors appear as a bottom-right alert and add a "Crear cuenta" button
- restyle register page to match login
- automatically log in after registration and redirect based on role

## Testing
- `npm install`
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68547595b8cc832f8f06df2f1d1359b1