### PR TITLE
Fix login register navigation

### DIFF
--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -56,7 +56,7 @@ import { LoginRequest } from '../../models';
             Usuario por defecto: <strong>admin</strong><br>
             Contraseña: <strong>admin</strong>
           </p>
-          <button type="button" class="btn-link register-btn" (click)="router.navigate(['/register'])">Crear cuenta</button>
+          <button type="button" class="btn-link register-btn" (click)="goToRegister()">Crear cuenta</button>
         </div>
         <div *ngIf="errorMessage" class="alert alert-error alert-fixed">
           {{ errorMessage }}
@@ -202,5 +202,9 @@ export class LoginComponent {
         console.error('Login error:', error);
       }
     });
+  }
+
+  goToRegister() {
+    this.router.navigate(['/register']);
   }
 }


### PR DESCRIPTION
## Summary
- fix TS2341 error by exposing router usage via `goToRegister()`

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685477b91834832f8ad44e9d0f243a95