### PR TITLE
Allow service manager to manage projects

### DIFF
--- a/backend/README2.md
+++ b/backend/README2.md
@@ -56,7 +56,7 @@ Ahora cada rol puede tener permisos asociados a las páginas del frontend. Usa l
 
 ## Clientes y proyectos
 
-Los clientes pueden ser creados y actualizados por usuarios con rol **Administrador** o **Gerente de servicios**, mientras que la eliminación sigue reservada al **Administrador**. Ahora el **Gerente de servicios** también puede asignar analistas a los clientes. Un cliente puede tener varios proyectos y ambos pueden inactivarse. Los analistas se asignan a los proyectos y solamente los analistas asignados (o los usuarios Administrador) pueden consultarlos.
+Los clientes pueden ser creados y actualizados por usuarios con rol **Administrador** o **Gerente de servicios**, mientras que la eliminación sigue reservada al **Administrador**. El **Gerente de servicios** puede crear proyectos para cada cliente y asignar analistas. Un cliente puede tener varios proyectos y ambos pueden inactivarse. Los analistas se asignan a los proyectos y solamente los analistas asignados (o los usuarios Administrador) pueden consultarlos. Cada proyecto cuenta con un **objetivo** y al asignar un analista se deben indicar la cantidad de **scripts por día** esperados y los **tipos de prueba** (funcional web, APIs, móviles, performance).
 Los roles **Analista de Pruebas** y **Automatizador de Pruebas** pueden consultar los clientes que tengan asignados y ver la dedicación indicada para cada uno.
 
 
@@ -71,7 +71,7 @@ Endpoints principales:
 - `POST /projects/` crear proyecto vinculado a un cliente
 - `PUT /projects/{id}` actualizar proyecto
 - `DELETE /projects/{id}` inactivar proyecto
-- `POST /projects/{id}/analysts/{user_id}` asignar analista
+- `POST /projects/{id}/analysts/{user_id}` asignar analista (parámetros `scripts_per_day` y `test_types`)
 - `DELETE /projects/{id}/analysts/{user_id}` quitar analista
 - `GET /projects/` listar proyectos asignados al usuario
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -79,6 +79,8 @@ project_analysts = Table(
     Base.metadata,
     Column("project_id", Integer, ForeignKey("projects.id"), primary_key=True),
     Column("user_id", Integer, ForeignKey("users.id"), primary_key=True),
+    Column("scripts_per_day", Integer, nullable=True),
+    Column("test_types", String, nullable=True),
 )
 
 
@@ -122,6 +124,7 @@ class Project(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    objetivo = Column(String, nullable=True)
     is_active = Column(Boolean, default=True)
 
     client = relationship("Client", back_populates="projects")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -100,6 +100,7 @@ class Client(ClientBase):
 class ProjectBase(BaseModel):
     name: str
     client_id: int
+    objetivo: Optional[str] = None
 
 
 class ProjectCreate(ProjectBase):
@@ -110,6 +111,8 @@ class Project(ProjectBase):
     id: int
     is_active: bool
     analysts: List[User] = []
+    scripts_per_day: Optional[int] = None
+    test_types: Optional[str] = None
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- add objective field to projects
- track scripts per day and test types per analyst assignment
- let service managers create/update/delete projects and manage assignments
- document new behaviour

## Testing
- `python -m py_compile backend/app/*.py`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685478ba2e04832f94a7882d56dc04fc