### PR TITLE
Improve client selection UI on dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,11 +1,27 @@
 <div class="dashboard-container">
-  <div *ngIf="!selectedClient">
-    <h2>Selecciona un Cliente</h2>
-    <ul class="list-group">
-      <li class="list-group-item" *ngFor="let c of clients">
-        <button class="btn btn-link" (click)="selectClient(c)">{{ c.name }}</button>
-      </li>
-    </ul>
+  <div *ngIf="!selectedClient" class="client-selection">
+    <h2 class="text-center">Selecciona un Cliente</h2>
+    <table class="table table-striped w-auto mx-auto">
+      <tbody>
+        <tr *ngFor="let c of paginatedClients()">
+          <td>{{ c.name }}</td>
+          <td class="text-end">
+            <button class="btn btn-link" (click)="selectClient(c)">Seleccionar</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <nav>
+      <ul class="pagination justify-content-center mb-0">
+        <li class="page-item" [class.disabled]="clientPage === 1">
+          <button class="page-link" (click)="clientPrev()">Anterior</button>
+        </li>
+        <li class="page-item"><span class="page-link">{{ clientPage }}</span></li>
+        <li class="page-item" [class.disabled]="clientPageEnd">
+          <button class="page-link" (click)="clientNext()" [disabled]="clientPageEnd">Siguiente</button>
+        </li>
+      </ul>
+    </nav>
   </div>
 
   <div *ngIf="selectedClient && !selectedProject">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -3,6 +3,16 @@
   padding: 0;
 }
 
+.client-selection {
+  max-width: 600px;
+  margin: 2rem auto;
+  text-align: center;
+
+  table {
+    margin-bottom: 1rem;
+  }
+}
+
 .dashboard-header {
   background: linear-gradient(135deg, var(--bg-general) 0%, var(--bg-general-alt) 100%);
   padding: 2rem 0;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -20,6 +20,8 @@ export class DashboardComponent implements OnInit {
   agents: Agent[] = [];
   clients: Client[] = [];
   projects: Project[] = [];
+  clientPage = 1;
+  readonly clientPageSize = 10;
   selectedClient: Client | null = null;
   selectedProject: Project | null = null;
   
@@ -48,12 +50,13 @@ export class DashboardComponent implements OnInit {
           this.currentUser.role?.name !== 'Administrador' &&
           this.currentUser.role?.name !== 'Gerente de servicios'
         ) {
-          this.clients = clients.filter(c =>
-            c.analysts.some(a => a.id === this.currentUser!.id)
-          );
+          this.clients = clients
+            .filter(c => c.is_active)
+            .filter(c => c.analysts.some(a => a.id === this.currentUser!.id));
         } else {
-          this.clients = clients;
+          this.clients = clients.filter(c => c.is_active);
         }
+        this.clientPage = 1;
       },
       error: err => console.error('Error loading clients:', err)
     });
@@ -226,6 +229,23 @@ export class DashboardComponent implements OnInit {
   createNewActor() {
     // Navigate to actor creation or open modal
     console.log('Create new actor');
+  }
+
+  paginatedClients(): Client[] {
+    const start = (this.clientPage - 1) * this.clientPageSize;
+    return this.clients.slice(start, start + this.clientPageSize);
+  }
+
+  get clientPageEnd(): boolean {
+    return this.clientPage * this.clientPageSize >= this.clients.length;
+  }
+
+  clientPrev() {
+    if (this.clientPage > 1) this.clientPage--;
+  }
+
+  clientNext() {
+    if (!this.clientPageEnd) this.clientPage++;
   }
 
   toggleUser(user: User) {


### PR DESCRIPTION
## Summary
- center the dashboard's client selection block
- display clients in a table with pagination
- show only active clients to the analyst

## Testing
- `npm install`
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_685478efbdb4832fb3684c29d4d7fd33