### PR TITLE
Fix service manager redirect and add project management

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -56,6 +56,10 @@ export const routes: Routes = [
     loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent)
   },
   {
+    path: 'projects',
+    loadComponent: () => import('./components/client-admin/client-projects.component').then(m => m.ClientProjectsComponent)
+  },
+  {
     path: 'client-admin',
     loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent)
   },

--- a/frontend/src/app/components/client-admin/client-admin.component.ts
+++ b/frontend/src/app/components/client-admin/client-admin.component.ts
@@ -8,11 +8,19 @@ import { Client, Project, User } from '../../models';
 import { ClientFormComponent } from './client-form.component';
 import { ProjectAnalystsComponent } from './project-analysts.component';
 import { ClientAnalystsComponent } from './client-analysts.component';
+import { ClientProjectsComponent } from './client-projects.component';
 
 @Component({
   selector: 'app-client-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, ClientFormComponent, ProjectAnalystsComponent, ClientAnalystsComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ClientFormComponent,
+    ProjectAnalystsComponent,
+    ClientAnalystsComponent,
+    ClientProjectsComponent
+  ],
 
   template: `
     <div class="main-panel">
@@ -39,6 +47,7 @@ import { ClientAnalystsComponent } from './client-analysts.component';
           <button class="btn btn-sm btn-secondary ms-2" (click)="edit(c)">Editar</button>
           <button class="btn btn-sm btn-danger ms-2" (click)="remove(c)">Inactivar</button>
           <button class="btn btn-sm btn-info ms-2" (click)="manageClientAnalysts(c)">Analistas</button>
+          <button class="btn btn-sm btn-warning ms-2" (click)="manageProjects(c)">Proyectos</button>
         </h3>
         <ul class="list-group">
           <li class="list-group-item" *ngFor="let p of projectsByClient(c.id)">
@@ -91,6 +100,17 @@ import { ClientAnalystsComponent } from './client-analysts.component';
         </div>
       </div>
       <div class="modal-backdrop fade show" *ngIf="selectedClient"></div>
+
+      <div class="modal fade show d-block" tabindex="-1" *ngIf="projectClient" (click)="projectClient=null">
+        <div class="modal-dialog modal-lg" (click)="$event.stopPropagation()">
+          <div class="modal-content">
+            <div class="modal-body">
+              <app-client-projects [clientId]="projectClient.id" (updated)="onProjectsUpdated()" (close)="projectClient=null"></app-client-projects>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-backdrop fade show" *ngIf="projectClient"></div>
   `
 })
 export class ClientAdminComponent implements OnInit {
@@ -100,6 +120,7 @@ export class ClientAdminComponent implements OnInit {
   editing: Client | null = null;
   selectedProject: Project | null = null;
   selectedClient: Client | null = null;
+  projectClient: Client | null = null;
   search = '';
   tab: 'active' | 'inactive' | 'history' = 'active';
   history: { client: string; action: string }[] = [];
@@ -188,6 +209,10 @@ export class ClientAdminComponent implements OnInit {
     this.selectedClient = c;
   }
 
+  manageProjects(c: Client) {
+    this.projectClient = c;
+  }
+
   onProjectAnalystsUpdated(e: { action: string; user: User }) {
     if (this.selectedProject) {
       const clientName = this.clients.find(cl => cl.id === this.selectedProject!.client_id)?.name || '';
@@ -201,6 +226,10 @@ export class ClientAdminComponent implements OnInit {
       this.history.push({ client: this.selectedClient.name, action: `${e.action} (${e.user.username})` });
       this.loadData();
     }
+  }
+
+  onProjectsUpdated() {
+    this.loadData();
   }
 
   onSaved(c: Client) {

--- a/frontend/src/app/components/client-admin/client-projects.component.ts
+++ b/frontend/src/app/components/client-admin/client-projects.component.ts
@@ -1,0 +1,98 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Client, Project, ProjectCreate } from '../../models';
+import { ClientService } from '../../services/client.service';
+import { ProjectService } from '../../services/project.service';
+
+@Component({
+  selector: 'app-client-projects',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="card" *ngIf="client">
+      <div class="card-body">
+        <h3 class="card-title">Proyectos de {{ client.name }}</h3>
+        <form (ngSubmit)="save()" class="mb-3">
+          <div class="input-group">
+            <input class="form-control" placeholder="Nombre del proyecto" [(ngModel)]="form.name" name="name" required>
+            <button class="btn btn-primary" type="submit">{{ editing ? 'Actualizar' : 'Crear' }}</button>
+            <button class="btn btn-secondary" type="button" *ngIf="editing" (click)="new()">Cancelar</button>
+          </div>
+        </form>
+        <ul class="list-group mb-3">
+          <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let p of projects">
+            {{ p.name }}
+            <span>
+              <button class="btn btn-sm btn-secondary me-2" (click)="edit(p)">Editar</button>
+              <button class="btn btn-sm btn-danger" (click)="remove(p)">Eliminar</button>
+            </span>
+          </li>
+        </ul>
+        <button class="btn btn-secondary" (click)="close.emit()">Cerrar</button>
+      </div>
+    </div>
+  `
+})
+export class ClientProjectsComponent implements OnChanges {
+  @Input() clientId!: number;
+  @Output() updated = new EventEmitter<void>();
+  @Output() close = new EventEmitter<void>();
+
+  client: Client | null = null;
+  projects: Project[] = [];
+  editing: Project | null = null;
+  form: ProjectCreate = { name: '', client_id: 0 };
+
+  constructor(
+    private clientService: ClientService,
+    private projectService: ProjectService
+  ) {}
+
+  ngOnChanges() {
+    if (this.clientId) {
+      this.load();
+    }
+  }
+
+  load() {
+    this.clientService.getClients().subscribe(cs => {
+      this.client = cs.find(c => c.id === this.clientId) || null;
+    });
+    this.projectService.getProjects().subscribe(ps => {
+      this.projects = ps.filter(p => p.client_id === this.clientId);
+    });
+    this.form.client_id = this.clientId;
+  }
+
+  new() {
+    this.editing = null;
+    this.form = { name: '', client_id: this.clientId };
+  }
+
+  edit(p: Project) {
+    this.editing = p;
+    this.form = { name: p.name, client_id: this.clientId };
+  }
+
+  save() {
+    const obs = this.editing
+      ? this.projectService.updateProject(this.editing.id, this.form)
+      : this.projectService.createProject(this.form);
+    obs.subscribe(() => {
+      this.load();
+      this.editing = null;
+      this.form = { name: '', client_id: this.clientId };
+      this.updated.emit();
+    });
+  }
+
+  remove(p: Project) {
+    if (confirm('¿Eliminar proyecto?')) {
+      this.projectService.deleteProject(p.id).subscribe(() => {
+        this.load();
+        this.updated.emit();
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add new `ClientProjectsComponent` for creating and managing projects
- show *Proyectos* button next to *Analistas* and modal for project CRUD
- wire modal into `ClientAdminComponent` and expose update handler
- register new `/projects` route

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685483515c8c832f8f1861600db75703