### PR TITLE
Fix analyst assignment error

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -72,8 +72,16 @@ class User(UserBase):
     last_login: Optional[datetime] = None
     is_active: bool
     role: Role
-    tests: List[Test] = []
-    projects: List["Project"] = []
+
+    class Config:
+        orm_mode = True
+
+
+class UserSummary(UserBase):
+    id: int
+    last_login: Optional[datetime] = None
+    is_active: bool
+    role: Role
 
     class Config:
         orm_mode = True
@@ -90,7 +98,7 @@ class ClientCreate(ClientBase):
 class Client(ClientBase):
     id: int
     is_active: bool
-    analysts: List[User] = []
+    analysts: List[UserSummary] = []
     dedication: int | None = None
 
     class Config:
@@ -110,7 +118,7 @@ class ProjectCreate(ProjectBase):
 class Project(ProjectBase):
     id: int
     is_active: bool
-    analysts: List[User] = []
+    analysts: List[UserSummary] = []
     scripts_per_day: Optional[int] = None
     test_types: Optional[str] = None
 

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -93,6 +93,12 @@ export class ProjectAnalystsComponent implements OnChanges {
 
   toggle(user: User, checked: boolean) {
     if (!this.project) return;
+    const msg = checked ?
+      `\u00bfAsignar analista ${user.username}?` :
+      `\u00bfQuitar analista ${user.username}?`;
+    if (!confirm(msg)) {
+      return;
+    }
     const obs = checked ?
       this.projectService.assignAnalyst(this.project.id, user.id) :
       this.projectService.unassignAnalyst(this.project.id, user.id);

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -9,8 +9,6 @@ export interface User {
   last_login?: string;
   is_active: boolean;
   role: Role;
-  tests: Test[];
-  projects: Project[];
 }
 
 export interface Client {


### PR DESCRIPTION
## Summary
- prevent cyclic references when returning projects with analysts
- confirm analyst assignment/removal via modal prompt
- update TypeScript models to match backend

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68548cabe570832f9bd72c354ada23a7