### PR TITLE
Implement workspace management in Angular

### DIFF
--- a/frontend/src/app/services/workspace.service.ts
+++ b/frontend/src/app/services/workspace.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, EventEmitter } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class WorkspaceService {
+  private clientSubject = new BehaviorSubject<number | null>(
+    WorkspaceService.loadNumber('clientId')
+  );
+  currentClient$ = this.clientSubject.asObservable();
+
+  private projectSubject = new BehaviorSubject<number | null>(
+    WorkspaceService.loadNumber('projectId')
+  );
+  currentProject$ = this.projectSubject.asObservable();
+
+  workspaceChanged = new EventEmitter<void>();
+
+  private static loadNumber(key: string): number | null {
+    const value = localStorage.getItem(key);
+    return value !== null ? Number(value) : null;
+  }
+
+  setWorkspace(clientId: number, projectId: number): void {
+    localStorage.setItem('clientId', String(clientId));
+    localStorage.setItem('projectId', String(projectId));
+    this.clientSubject.next(clientId);
+    this.projectSubject.next(projectId);
+    this.workspaceChanged.emit();
+  }
+
+  clearWorkspace(): void {
+    localStorage.removeItem('clientId');
+    localStorage.removeItem('projectId');
+    this.clientSubject.next(null);
+    this.projectSubject.next(null);
+    this.workspaceChanged.emit();
+  }
+
+  hasWorkspace(): boolean {
+    return (
+      this.clientSubject.value !== null &&
+      this.projectSubject.value !== null
+    );
+  }
+
+  get clientId(): number | null {
+    return this.clientSubject.value;
+  }
+
+  get projectId(): number | null {
+    return this.projectSubject.value;
+  }
+}

--- a/frontend/src/app/workspace.guard.ts
+++ b/frontend/src/app/workspace.guard.ts
@@ -1,0 +1,9 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { WorkspaceService } from './services/workspace.service';
+
+export const canActivateWorkspace: CanActivateFn = () => {
+  const workspace = inject(WorkspaceService);
+  const router = inject(Router);
+  return workspace.hasWorkspace() ? true : router.createUrlTree(['/dashboard']);
+};

--- a/frontend/src/app/workspace.interceptor.ts
+++ b/frontend/src/app/workspace.interceptor.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { WorkspaceService } from './services/workspace.service';
+
+@Injectable()
+export class WorkspaceInterceptor implements HttpInterceptor {
+  constructor(private workspace: WorkspaceService) {}
+
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    const headers: Record<string, string> = {};
+    if (this.workspace.clientId !== null) {
+      headers['X-Client-Id'] = String(this.workspace.clientId);
+    }
+    if (this.workspace.projectId !== null) {
+      headers['X-Project-Id'] = String(this.workspace.projectId);
+    }
+    const cloned = Object.keys(headers).length
+      ? req.clone({ setHeaders: headers })
+      : req;
+    return next.handle(cloned);
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,9 +2,10 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { importProvidersFrom } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 import { routes } from './app/app.routes';
+import { WorkspaceInterceptor } from './app/workspace.interceptor';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -12,6 +13,11 @@ bootstrapApplication(AppComponent, {
       BrowserAnimationsModule,
       HttpClientModule,
       RouterModule.forRoot(routes)
-    )
+    ),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: WorkspaceInterceptor,
+      multi: true
+    }
   ]
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- manage workspace selection with a new `WorkspaceService`
- add `canActivateWorkspace` guard to check selected workspace
- send workspace IDs in headers via `WorkspaceInterceptor`
- provide interceptor in application bootstrap

## Testing
- `npm install`
- `npx ng test --watch=false` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_685492100048832fb382654b9f58d0a3