### PR TITLE
Implement workspace and client access controls

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Table, Date, DateTime, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    ForeignKey,
+    Table,
+    Date,
+    DateTime,
+    UniqueConstraint,
+)
 import enum
 from datetime import datetime
 from sqlalchemy.orm import relationship
@@ -14,15 +24,14 @@ class Role(Base):
 
 class PagePermission(Base):
     __tablename__ = "permissions"
-    __table_args__ = (
-        UniqueConstraint("role_id", "page", name="uix_role_page"),
-    )
+    __table_args__ = (UniqueConstraint("role_id", "page", name="uix_role_page"),)
 
     id = Column(Integer, primary_key=True, index=True)
     role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
     page = Column(String, nullable=False)
 
     role = relationship("Role", backref="permissions")
+
 
 class User(Base):
     __tablename__ = "users"
@@ -45,6 +54,7 @@ class User(Base):
         secondary="client_analysts",
         back_populates="analysts",
     )
+
 
 class TestCase(Base):
     __tablename__ = "tests"
@@ -230,6 +240,7 @@ class ActionAssignment(Base):
     element = relationship("PageElement")
     test = relationship("TestCase")
 
+
 class ExecutionAgent(Base):
     __tablename__ = "agents"
     id = Column(Integer, primary_key=True, index=True)
@@ -256,6 +267,7 @@ class ExecutionStatus(str, enum.Enum):
     RUNNING = "En ejecucion"
     FINISHED = "Finalizado"
 
+
 class PlanExecution(Base):
     __tablename__ = "execution_records"
 
@@ -267,3 +279,16 @@ class PlanExecution(Base):
 
     plan = relationship("ExecutionPlan")
     agent = relationship("ExecutionAgent")
+
+
+class Workspace(Base):
+    __tablename__ = "workspaces"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), unique=True, nullable=False)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True)
+
+    user = relationship("User")
+    client = relationship("Client")
+    project = relationship("Project")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -33,6 +33,7 @@ class Permission(PermissionBase):
     class Config:
         orm_mode = True
 
+
 class TestBase(BaseModel):
     name: str
     description: Optional[str] = None
@@ -43,8 +44,10 @@ class TestBase(BaseModel):
     then: Optional[str] = None
     test_plan_id: Optional[int] = None
 
+
 class TestCreate(TestBase):
     pass
+
 
 class Test(TestBase):
     id: int
@@ -54,8 +57,10 @@ class Test(TestBase):
     class Config:
         orm_mode = True
 
+
 class UserBase(BaseModel):
     username: str
+
 
 class UserCreate(UserBase):
     password: str
@@ -64,8 +69,10 @@ class UserCreate(UserBase):
 class UserRoleUpdate(BaseModel):
     role_id: int
 
+
 class UserActiveUpdate(BaseModel):
     is_active: bool
+
 
 class User(UserBase):
     id: int
@@ -242,6 +249,7 @@ class ActionAssignment(ActionAssignmentBase):
     class Config:
         orm_mode = True
 
+
 class AgentBase(BaseModel):
     alias: str = Field(..., min_length=1)
     hostname: str = Field(..., min_length=1)
@@ -250,8 +258,8 @@ class AgentBase(BaseModel):
 
     @root_validator(skip_on_failure=True)
     def validate_fields(cls, values):
-        os_val = values.get('os')
-        categoria = values.get('categoria')
+        os_val = values.get("os")
+        categoria = values.get("categoria")
         allowed = ["Windows", "Linux", "Mac", "Android", "iOS"]
         if os_val not in allowed:
             raise ValueError("Invalid operating system")
@@ -262,8 +270,10 @@ class AgentBase(BaseModel):
                 raise ValueError("categoria only allowed for Android/iOS agents")
         return values
 
+
 class AgentCreate(AgentBase):
     pass
+
 
 class Agent(AgentBase):
     id: int
@@ -287,6 +297,7 @@ class ExecutionPlan(ExecutionPlanBase):
 
     class Config:
         orm_mode = True
+
 
 class PlanExecutionBase(BaseModel):
     plan_id: int
@@ -322,3 +333,20 @@ class ClientDetail(Client):
 class Metrics(BaseModel):
     clients: List[ClientDetail]
     flows: List[Test]
+
+
+class WorkspaceBase(BaseModel):
+    client_id: int
+    project_id: Optional[int] = None
+
+
+class WorkspaceCreate(WorkspaceBase):
+    pass
+
+
+class Workspace(WorkspaceBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add `Workspace` model and matching schemas
- filter endpoints with new `/clients/assigned` and `/projects/by-client/{client_id}` routes
- add workspace selection and retrieval endpoints
- restrict service managers to modify only their own clients/projects

## Testing
- `black backend/app/models.py backend/app/schemas.py backend/app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685492087a0c832f8312bcbab7bd77db