### PR TITLE
Implement workspace-aware dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -40,17 +40,42 @@
   </div>
 
   <ng-container *ngIf="selectedProject">
-  <!-- Header -->
-  <header class="dashboard-header">
-    <h1 class="fade-in">Analista de Pruebas</h1>
-    <div class="user-info" *ngIf="currentUser">
-      <span class="text-secondary">Bienvenido, {{ currentUser.username }}</span>
-      <span class="badge badge-role">{{ currentUser.role?.name }}</span>
-    </div>
-  </header>
+  <div class="dashboard-layout">
+    <aside class="side-menu" *ngIf="menu.length">
+      <ul>
+        <li *ngFor="let m of menu"><a [routerLink]="m.route">{{ m.label }}</a></li>
+      </ul>
+      <button class="btn btn-sm btn-link" (click)="changeWorkspace()">Cambiar cliente/proyecto</button>
+    </aside>
+    <div class="dashboard-content">
+      <!-- Header -->
+      <header class="dashboard-header">
+        <h1 class="fade-in">Analista de Pruebas</h1>
+        <div class="user-info" *ngIf="currentUser">
+          <span class="text-secondary">{{ currentUser.username }}</span>
+          <span class="badge badge-role">{{ currentUser.role?.name }}</span>
+        </div>
+        <div class="workspace-info">
+          Cliente: {{ selectedClient?.name }} | Proyecto: {{ selectedProject?.name }}
+        </div>
+      </header>
+      <div class="summary-cards">
+        <div class="summary-card">
+          <h3>{{ scriptsToday }}</h3>
+          <p>Scripts hoy</p>
+        </div>
+        <div class="summary-card">
+          <h3>{{ pendingExecutions }}</h3>
+          <p>Ejecuciones pendientes</p>
+        </div>
+        <div class="summary-card">
+          <h3>{{ lastExecution?.started_at ? (lastExecution.started_at | date:'short') : '-' }}</h3>
+          <p>Última ejecución</p>
+        </div>
+      </div>
 
-  <!-- Main Panel -->
-  <div class="main-panel">
+      <!-- Main Panel -->
+      <div class="main-panel">
     
     <!-- Gestión de Actores Section -->
     <div class="section">
@@ -304,6 +329,8 @@
           </tr>
         </tbody>
       </table>
+    </div>
+  </div>
     </div>
   </div>
   </ng-container>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -645,3 +645,53 @@
     max-width: 66.666667%;
   }
 }
+
+.dashboard-layout {
+  display: flex;
+  gap: 1rem;
+}
+
+.side-menu {
+  width: 200px;
+}
+
+.side-menu ul {
+  list-style: none;
+  padding: 0;
+}
+
+.side-menu li {
+  margin-bottom: 0.5rem;
+}
+
+.side-menu a {
+  text-decoration: none;
+  color: var(--title-color);
+}
+
+.side-menu a:hover {
+  text-decoration: underline;
+}
+
+.dashboard-content {
+  flex: 1;
+}
+
+.workspace-info {
+  margin-top: 0.5rem;
+}
+
+.summary-cards {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.summary-card {
+  flex: 1;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- check workspace on dashboard init and redirect if missing
- populate dashboard menu depending on role
- persist selected project in workspace service
- show workspace info, menu and summary cards

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549391115c832fa11ee94387308f89