### PR TITLE
Add Service Manager component with project and team management

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -64,6 +64,10 @@ export const routes: Routes = [
     loadComponent: () => import('./components/client-admin/client-projects.component').then(m => m.ClientProjectsComponent)
   },
   {
+    path: 'service-manager',
+    loadComponent: () => import('./components/service-manager/service-manager.component').then(m => m.ServiceManagerComponent)
+  },
+  {
     path: 'client-admin',
     loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent)
   },

--- a/frontend/src/app/components/client-admin/client-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/client-analysts.component.ts
@@ -14,13 +14,14 @@ import { ApiService } from '../../services/api.service';
       <div class="card-body">
         <h3 class="card-title">Analistas de {{ client.name }}</h3>
         <input class="form-control mb-2" placeholder="Buscar..." [(ngModel)]="search" (ngModelChange)="onSearch()" />
-        <div *ngFor="let u of analysts" class="form-check">
-          <input class="form-check-input" type="checkbox" [id]="'ca-'+u.id"
+        <div *ngFor="let u of analysts" class="form-check d-flex align-items-center mb-1">
+          <input class="form-check-input me-2" type="checkbox" [id]="'ca-'+u.id"
             [checked]="isAssigned(u)"
             (change)="toggle(u, $any($event.target).checked)">
-          <label class="form-check-label" [for]="'ca-'+u.id">
+          <label class="form-check-label me-2" [for]="'ca-'+u.id">
             {{ u.username }} ({{ u.role.name }})
           </label>
+          <input type="number" class="form-control form-control-sm" style="width:80px" [(ngModel)]="dedication[u.id]" placeholder="% dedicación">
         </div>
         <nav class="mt-2">
           <ul class="pagination mb-0">
@@ -48,6 +49,7 @@ export class ClientAnalystsComponent implements OnChanges {
 
   client: Client | null = null;
   analysts: User[] = [];
+  dedication: { [id: number]: number } = {};
   page = 1;
   search = '';
 
@@ -95,7 +97,7 @@ export class ClientAnalystsComponent implements OnChanges {
   toggle(user: User, checked: boolean) {
     if (!this.client) return;
     const obs = checked
-      ? this.clientService.assignAnalyst(this.client.id, user.id)
+      ? this.clientService.assignAnalyst(this.client.id, user.id, this.dedication[user.id] || 100)
       : this.clientService.unassignAnalyst(this.client.id, user.id);
     obs.subscribe(c => {
       this.client = c;

--- a/frontend/src/app/components/client-admin/client-projects.component.ts
+++ b/frontend/src/app/components/client-admin/client-projects.component.ts
@@ -14,11 +14,12 @@ import { ProjectService } from '../../services/project.service';
       <div class="card-body">
         <h3 class="card-title">Proyectos de {{ client.name }}</h3>
         <form (ngSubmit)="save()" class="mb-3">
-          <div class="input-group">
+          <div class="input-group mb-2">
             <input class="form-control" placeholder="Nombre del proyecto" [(ngModel)]="form.name" name="name" required>
-            <button class="btn btn-primary" type="submit">{{ editing ? 'Actualizar' : 'Crear' }}</button>
-            <button class="btn btn-secondary" type="button" *ngIf="editing" (click)="new()">Cancelar</button>
+            <input class="form-control" placeholder="Objetivo" [(ngModel)]="form.objetivo" name="objetivo">
           </div>
+          <button class="btn btn-primary me-2" type="submit">{{ editing ? 'Actualizar' : 'Crear' }}</button>
+          <button class="btn btn-secondary" type="button" *ngIf="editing" (click)="new()">Cancelar</button>
         </form>
         <ul class="list-group mb-3">
           <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let p of projects">
@@ -42,7 +43,7 @@ export class ClientProjectsComponent implements OnChanges {
   client: Client | null = null;
   projects: Project[] = [];
   editing: Project | null = null;
-  form: ProjectCreate = { name: '', client_id: 0 };
+  form: ProjectCreate = { name: '', client_id: 0, objetivo: '' };
 
   constructor(
     private clientService: ClientService,
@@ -67,12 +68,12 @@ export class ClientProjectsComponent implements OnChanges {
 
   new() {
     this.editing = null;
-    this.form = { name: '', client_id: this.clientId };
+    this.form = { name: '', client_id: this.clientId, objetivo: '' };
   }
 
   edit(p: Project) {
     this.editing = p;
-    this.form = { name: p.name, client_id: this.clientId };
+    this.form = { name: p.name, client_id: this.clientId, objetivo: p.objetivo };
   }
 
   save() {
@@ -82,7 +83,7 @@ export class ClientProjectsComponent implements OnChanges {
     obs.subscribe(() => {
       this.load();
       this.editing = null;
-      this.form = { name: '', client_id: this.clientId };
+      this.form = { name: '', client_id: this.clientId, objetivo: '' };
       this.updated.emit();
     });
   }

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -14,13 +14,14 @@ import { ApiService } from '../../services/api.service';
       <div class="card-body">
         <h3 class="card-title">Analistas de {{ project.name }}</h3>
         <input class="form-control mb-2" placeholder="Buscar..." [(ngModel)]="search" (ngModelChange)="onSearch()" />
-        <div *ngFor="let u of analysts" class="form-check">
-          <input class="form-check-input" type="checkbox" [id]="'an-'+u.id"
+        <div *ngFor="let u of analysts" class="form-check d-flex align-items-center mb-1">
+          <input class="form-check-input me-2" type="checkbox" [id]="'an-'+u.id"
             [checked]="isAssigned(u)"
             (change)="toggle(u, $any($event.target).checked)">
-          <label class="form-check-label" [for]="'an-'+u.id">
+          <label class="form-check-label me-2" [for]="'an-'+u.id">
             {{ u.username }} ({{ u.role.name }})
           </label>
+          <input type="number" class="form-control form-control-sm" style="width:90px" [(ngModel)]="scripts[u.id]" placeholder="scripts/día">
         </div>
         <nav class="mt-2">
           <ul class="pagination mb-0">
@@ -48,6 +49,7 @@ export class ProjectAnalystsComponent implements OnChanges {
 
   project: Project | null = null;
   analysts: User[] = [];
+  scripts: { [id: number]: number } = {};
   page = 1;
   search = '';
 
@@ -100,7 +102,7 @@ export class ProjectAnalystsComponent implements OnChanges {
       return;
     }
     const obs = checked ?
-      this.projectService.assignAnalyst(this.project.id, user.id) :
+      this.projectService.assignAnalyst(this.project.id, user.id, this.scripts[user.id] || 0) :
       this.projectService.unassignAnalyst(this.project.id, user.id);
     obs.subscribe(p => {
       this.project = p;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -310,9 +310,7 @@ export class DashboardComponent implements OnInit {
 
   setMenuByRole(role: string) {
     const gs = [
-      { label: 'Clientes', route: '/client-admin' },
-      { label: 'Proyectos', route: '/projects' },
-      { label: 'Asignar analistas', route: '/client-admin' }
+      { label: 'Gestión', route: '/service-manager' }
     ];
     const analyst = [
       { label: 'Crear scripts', route: '/test-cases' },

--- a/frontend/src/app/components/service-manager/service-manager.component.ts
+++ b/frontend/src/app/components/service-manager/service-manager.component.ts
@@ -1,0 +1,156 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Client, Project, User } from '../../models';
+import { ClientService } from '../../services/client.service';
+import { ProjectService } from '../../services/project.service';
+import { ApiService } from '../../services/api.service';
+import { ClientAnalystsComponent } from '../client-admin/client-analysts.component';
+import { ProjectAnalystsComponent } from '../client-admin/project-analysts.component';
+import { ClientProjectsComponent } from '../client-admin/client-projects.component';
+
+@Component({
+  selector: 'app-service-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ClientAnalystsComponent, ProjectAnalystsComponent, ClientProjectsComponent],
+  template: `
+    <div class="main-panel">
+      <h1>Gerencia de Servicio</h1>
+      <ul class="nav nav-tabs mb-3">
+        <li class="nav-item"><a class="nav-link" [class.active]="tab==='clients'" (click)="tab='clients'">Clientes</a></li>
+        <li class="nav-item"><a class="nav-link" [class.active]="tab==='projects'" (click)="tab='projects'">Proyectos</a></li>
+        <li class="nav-item"><a class="nav-link" [class.active]="tab==='team'" (click)="tab='team'">Equipo</a></li>
+      </ul>
+
+      <div *ngIf="tab==='clients'">
+        <label class="form-label w-100 mb-2">Nuevo cliente:
+          <input class="form-control" [(ngModel)]="newClient" placeholder="Nombre" />
+        </label>
+        <button class="btn btn-primary mb-3" (click)="createClient()">Crear</button>
+        <ul class="list-group">
+          <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let c of clients">
+            {{c.name}} <span>
+              <button class="btn btn-sm btn-info" (click)="openClientAnalysts(c)">Analistas</button>
+              <button class="btn btn-sm btn-warning" (click)="openProjects(c)">Proyectos</button>
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div *ngIf="tab==='projects'">
+        <label class="form-label">Cliente:
+          <select class="form-select" [(ngModel)]="filterClient">
+            <option [ngValue]="0">Todos</option>
+            <option *ngFor="let c of clients" [ngValue]="c.id">{{c.name}}</option>
+          </select>
+        </label>
+        <ul class="list-group">
+          <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let p of filteredProjects()">
+            {{p.name}}
+            <span>
+              <button class="btn btn-sm btn-info" (click)="openProjectAnalysts(p)">Analistas</button>
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div *ngIf="tab==='team'">
+        <table class="table">
+          <thead><tr><th>Analista</th><th>Proyectos</th><th>Carga</th><th>Reasignar</th></tr></thead>
+          <tbody>
+            <tr *ngFor="let a of team()">
+              <td>{{a.user.username}}</td>
+              <td>{{a.projects.map(p=>p.name).join(', ')}}</td>
+              <td>{{a.load}}</td>
+              <td>
+                <select class="form-select form-select-sm mb-1" [(ngModel)]="reassignTarget[a.user.id]">
+                  <option *ngFor="let p of projects" [ngValue]="p.id">{{p.name}}</option>
+                </select>
+                <button class="btn btn-sm btn-secondary" (click)="reassign(a.user, reassignTarget[a.user.id])">Mover</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="mt-4">
+        <h3>Métricas</h3>
+        <p>Proyectos activos: {{activeProjects}}</p>
+        <p>Analistas asignados: {{assignedAnalysts}}</p>
+        <p>Capacidad del equipo: {{teamCapacity}}</p>
+      </div>
+
+      <app-client-analysts [clientId]="selectedClient?.id" (updated)="loadData()" (close)="selectedClient=null" *ngIf="selectedClient"></app-client-analysts>
+      <app-project-analysts [projectId]="selectedProject?.id" (updated)="loadData()" (close)="selectedProject=null" *ngIf="selectedProject"></app-project-analysts>
+      <app-client-projects [clientId]="projectClient?.id" (updated)="loadData()" (close)="projectClient=null" *ngIf="projectClient"></app-client-projects>
+    </div>
+  `
+})
+export class ServiceManagerComponent implements OnInit {
+  tab: 'clients' | 'projects' | 'team' = 'clients';
+  clients: Client[] = [];
+  projects: Project[] = [];
+  analysts: User[] = [];
+
+  newClient = '';
+  filterClient = 0;
+  selectedClient: Client | null = null;
+  selectedProject: Project | null = null;
+  projectClient: Client | null = null;
+  reassignTarget: { [id: number]: number } = {};
+
+  constructor(private clientService: ClientService, private projectService: ProjectService, private api: ApiService) {}
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  loadData() {
+    this.clientService.getClients().subscribe(cs => this.clients = cs);
+    this.projectService.getProjects().subscribe(ps => this.projects = ps);
+    this.api.getAnalysts(undefined,1).subscribe(as => this.analysts = as);
+  }
+
+  createClient() {
+    const name = this.newClient.trim();
+    if (!name) return;
+    this.clientService.createClient({name}).subscribe(() => {
+      this.newClient='';
+      this.loadData();
+    });
+  }
+
+  openClientAnalysts(c: Client) { this.selectedClient = c; }
+  openProjectAnalysts(p: Project) { this.selectedProject = p; }
+  openProjects(c: Client) { this.projectClient = c; }
+
+  filteredProjects(): Project[] {
+    return this.filterClient ? this.projects.filter(p => p.client_id === this.filterClient) : this.projects;
+  }
+
+  team() {
+    const map = new Map<number, {user: User, projects: Project[], load: number}>();
+    for (const p of this.projects) {
+      for (const a of p.analysts) {
+        const entry = map.get(a.id) || {user: a, projects: [], load:0};
+        entry.projects.push(p);
+        entry.load += p.scripts_per_day || 0;
+        map.set(a.id, entry);
+      }
+    }
+    return Array.from(map.values());
+  }
+
+  reassign(user: User, projectId: number) {
+    if (!projectId) return;
+    const current = this.projects.find(p => p.analysts.some(a => a.id===user.id));
+    if (!current || current.id === projectId) return;
+    this.projectService.unassignAnalyst(current.id, user.id).subscribe(() => {
+      this.projectService.assignAnalyst(projectId, user.id).subscribe(() => this.loadData());
+    });
+  }
+
+  get activeProjects() { return this.projects.filter(p => p.is_active).length; }
+  get assignedAnalysts() { const ids = new Set<number>(); this.projects.forEach(p=>p.analysts.forEach(a=>ids.add(a.id))); return ids.size; }
+  get teamCapacity() { let sum=0; this.projects.forEach(p=>{ sum += p.scripts_per_day || 0; }); return sum; }
+}

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -24,6 +24,9 @@ export interface Project {
   client_id: number;
   is_active: boolean;
   analysts: User[];
+  objetivo?: string;
+  scripts_per_day?: number;
+  test_types?: string;
 }
 
 export interface Actor {
@@ -148,6 +151,7 @@ export interface ClientCreate {
 export interface ProjectCreate {
   name: string;
   client_id: number;
+  objetivo?: string;
 }
 
 export interface TestCreate {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -161,8 +161,12 @@ export class ApiService {
     return this.http.get<Project[]>(`${this.baseUrl}/projects/by-client/${clientId}`, { headers: this.getHeaders() });
   }
 
-  assignAnalyst(projectId: number, userId: number): Observable<Project> {
-    return this.http.post<Project>(`${this.baseUrl}/projects/${projectId}/analysts/${userId}`, {}, { headers: this.getHeaders() });
+  assignAnalyst(projectId: number, userId: number, scriptsPerDay?: number): Observable<Project> {
+    let url = `${this.baseUrl}/projects/${projectId}/analysts/${userId}`;
+    if (scriptsPerDay !== undefined) {
+      url += `?scripts_per_day=${scriptsPerDay}`;
+    }
+    return this.http.post<Project>(url, {}, { headers: this.getHeaders() });
   }
 
   unassignAnalyst(projectId: number, userId: number): Observable<Project> {

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -31,8 +31,8 @@ export class ProjectService {
     return this.api.deleteProject(id);
   }
 
-  assignAnalyst(projectId: number, userId: number): Observable<Project> {
-    return this.api.assignAnalyst(projectId, userId);
+  assignAnalyst(projectId: number, userId: number, scriptsPerDay?: number): Observable<Project> {
+    return this.api.assignAnalyst(projectId, userId, scriptsPerDay);
   }
 
   unassignAnalyst(projectId: number, userId: number): Observable<Project> {


### PR DESCRIPTION
## Summary
- add new Service Manager page with tabs for clients, projects and team
- allow setting project objective and script count per analyst
- allow setting dedication when assigning analysts to a client
- extend API/service methods to support new parameters
- adjust dashboard menu and routing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549698b074832f8124d5414651ae84