### PR TITLE
Add script management component

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -68,6 +68,7 @@ class TestCase(Base):
     when = Column(String, nullable=True)
     then = Column(String, nullable=True)
     test_plan_id = Column(Integer, ForeignKey("testplans.id"), nullable=True)
+    actor_id = Column(Integer, ForeignKey("actors.id"), nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
 
     owner = relationship("User", back_populates="tests")
@@ -81,6 +82,7 @@ class TestCase(Base):
         secondary="test_actions",
         back_populates="tests",
     )
+    actor = relationship("Actor")
     plan = relationship("TestPlan")
 
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import os
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy import or_
 
 from . import models, schemas, deps, security, executor
 
@@ -1817,7 +1818,12 @@ def read_tests(
         models.TestCase.owner_id == current_user.id
     )
     if search is not None:
-        query = query.filter(models.TestCase.name.ilike(f"%{search}%"))
+        query = query.filter(
+            or_(
+                models.TestCase.name.ilike(f"%{search}%"),
+                models.TestCase.description.ilike(f"%{search}%")
+            )
+        )
     if priority is not None:
         query = query.filter(models.TestCase.priority == priority)
     if status is not None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -43,6 +43,7 @@ class TestBase(BaseModel):
     when: Optional[str] = None
     then: Optional[str] = None
     test_plan_id: Optional[int] = None
+    actor_id: Optional[int] = None
 
 
 class TestCreate(TestBase):

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -44,6 +44,10 @@ export const routes: Routes = [
     loadComponent: () => import('./components/test-cases/test-cases.component').then(m => m.TestCasesComponent)
   },
   {
+    path: 'scripts',
+    loadComponent: () => import('./components/scripts/scripts.component').then(m => m.ScriptsComponent)
+  },
+  {
     path: 'pages',
     loadComponent: () => import('./components/pages/pages.component').then(m => m.PagesComponent)
   },

--- a/frontend/src/app/components/scripts/parameter-dialog.component.ts
+++ b/frontend/src/app/components/scripts/parameter-dialog.component.ts
@@ -1,0 +1,87 @@
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Action, PageElement } from '../../models';
+import { ElementService } from '../../services/element.service';
+import { ActionService } from '../../services/action.service';
+import { TestCaseService } from '../../services/test-case.service';
+
+@Component({
+  selector: 'app-parameter-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="parameter-form">
+      <h3>Parametrizar Script</h3>
+      <form (ngSubmit)="submit()">
+        <div class="form-group">
+          <label>Elemento</label>
+          <select class="form-control" [(ngModel)]="elementId" name="element">
+            <option [ngValue]="null">--</option>
+            <option *ngFor="let el of elements" [ngValue]="el.id">{{ el.name }}</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Acción</label>
+          <select class="form-control" [(ngModel)]="actionId" name="action">
+            <option [ngValue]="null">--</option>
+            <option *ngFor="let a of actions" [ngValue]="a.id">{{ a.name }}</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Parámetros (JSON)</label>
+          <input class="form-control" [(ngModel)]="params" name="params">
+        </div>
+        <div class="mt-3">
+          <button class="btn btn-primary mr-2" type="submit">Guardar</button>
+          <button class="btn btn-secondary" type="button" (click)="cancel.emit()">Cancelar</button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .parameter-form { padding: 1rem; }
+    .form-group { margin-bottom: 1rem; }
+    .mr-2 { margin-right: 0.5rem; }
+  `]
+})
+export class ParameterDialogComponent implements OnInit {
+  @Input() testId!: number;
+  @Output() saved = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  elements: PageElement[] = [];
+  actions: Action[] = [];
+  elementId: number | null = null;
+  actionId: number | null = null;
+  params = '';
+
+  constructor(
+    private elementService: ElementService,
+    private actionService: ActionService,
+    private testService: TestCaseService
+  ) {}
+
+  ngOnInit() {
+    this.elementService.getElements().subscribe(e => this.elements = e);
+    this.actionService.getActions().subscribe(a => this.actions = a);
+  }
+
+  submit() {
+    if (!this.elementId || !this.actionId) return;
+    let parametros: any;
+    if (this.params) {
+      try { parametros = JSON.parse(this.params); } catch { alert('JSON inválido'); return; }
+    }
+    this.elementService.addToTest(this.elementId, this.testId).subscribe(() => {
+      this.actionService.createAssignment({
+        action_id: this.actionId!,
+        element_id: this.elementId!,
+        test_id: this.testId,
+        parametros
+      }).subscribe(() => {
+        this.testService.updateTestCase(this.testId, { status: 'parametrizado' } as any).subscribe(() => this.saved.emit());
+      });
+    });
+  }
+}

--- a/frontend/src/app/components/scripts/scripts.component.ts
+++ b/frontend/src/app/components/scripts/scripts.component.ts
@@ -1,0 +1,110 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Test } from '../../models';
+import { TestCaseService } from '../../services/test-case.service';
+import { ParameterDialogComponent } from './parameter-dialog.component';
+import { TestCaseFormComponent } from '../test-cases/test-case-form.component';
+
+@Component({
+  selector: 'app-scripts',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ParameterDialogComponent, TestCaseFormComponent],
+  template: `
+    <div class="main-panel">
+      <h1>Gestión de Scripts</h1>
+      <div class="filters mb-3">
+        <input class="form-control mb-2" [(ngModel)]="search" placeholder="Buscar" (ngModelChange)="filter()">
+        <div class="d-flex flex-wrap gap-2">
+          <select class="form-control" [(ngModel)]="priority" (change)="filter()">
+            <option value="">Prioridad</option>
+            <option value="alta">Alta</option>
+            <option value="media">Media</option>
+            <option value="baja">Baja</option>
+          </select>
+          <select class="form-control" [(ngModel)]="status" (change)="filter()">
+            <option value="">Estado</option>
+            <option value="creado">Creado</option>
+            <option value="parametrizado">Parametrizado</option>
+            <option value="listo">Listo para ejecutar</option>
+          </select>
+          <button class="btn btn-primary" (click)="newTest()">Nuevo</button>
+        </div>
+      </div>
+
+      <table class="table table-bordered" *ngIf="filtered.length > 0">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Prioridad</th>
+            <th>Estado</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let t of filtered">
+            <td>{{ t.name }}</td>
+            <td>{{ t.priority || '-' }}</td>
+            <td>{{ t.status || 'creado' }}</td>
+            <td>
+              <button class="btn btn-sm btn-secondary mr-2" (click)="edit(t)">Editar</button>
+              <button class="btn btn-sm btn-info mr-2" (click)="param(t)">Parametrizar</button>
+              <button class="btn btn-sm btn-danger" (click)="remove(t)">Eliminar</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div *ngIf="filtered.length === 0" class="mt-3">No hay scripts.</div>
+
+      <app-test-case-form *ngIf="showForm" [test]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-test-case-form>
+      <app-parameter-dialog *ngIf="showParam" [testId]="paramId!" (saved)="onParamSaved()" (cancel)="showParam=false"></app-parameter-dialog>
+    </div>
+  `,
+  styles: [`
+    .filters { max-width: 600px; }
+    .gap-2 { gap: 0.5rem; }
+    .mr-2 { margin-right: 0.25rem; }
+  `]
+})
+export class ScriptsComponent implements OnInit {
+  tests: Test[] = [];
+  filtered: Test[] = [];
+  search = '';
+  priority = '';
+  status = '';
+
+  showForm = false;
+  editing: Test | null = null;
+
+  showParam = false;
+  paramId: number | null = null;
+
+  constructor(private service: TestCaseService) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.service.getTestCases().subscribe(t => { this.tests = t; this.filter(); });
+  }
+
+  filter() {
+    const term = this.search.toLowerCase();
+    this.filtered = this.tests.filter(t => {
+      const matchText = t.name.toLowerCase().includes(term) || (t.description || '').toLowerCase().includes(term);
+      const matchPriority = this.priority ? t.priority === this.priority : true;
+      const matchStatus = this.status ? t.status === this.status : true;
+      return matchText && matchPriority && matchStatus;
+    });
+  }
+
+  newTest() { this.editing = null; this.showForm = true; }
+  edit(t: Test) { this.editing = t; this.showForm = true; }
+  remove(t: Test) { if (confirm('¿Eliminar script?')) this.service.deleteTestCase(t.id).subscribe(() => this.load()); }
+
+  onSaved() { this.showForm = false; this.load(); }
+
+  param(t: Test) { this.paramId = t.id; this.showParam = true; }
+  onParamSaved() { this.showParam = false; this.load(); }
+}

--- a/frontend/src/app/components/test-cases/test-case-form.component.ts
+++ b/frontend/src/app/components/test-cases/test-case-form.component.ts
@@ -1,9 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Test, TestCreate, TestPlan } from '../../models';
+import { Test, TestCreate, TestPlan, Actor } from '../../models';
 import { TestCaseService } from '../../services/test-case.service';
 import { ApiService } from '../../services/api.service';
+import { ActorService } from '../../services/actor.service';
+import { WorkspaceService } from '../../services/workspace.service';
 
 @Component({
   selector: 'app-test-case-form',
@@ -52,6 +54,13 @@ import { ApiService } from '../../services/api.service';
           </select>
         </div>
         <div class="form-group">
+          <label>Actor</label>
+          <select class="form-control" [(ngModel)]="form.actor_id" name="actor">
+            <option [ngValue]="null">--</option>
+            <option *ngFor="let a of actors" [ngValue]="a.id">{{ a.name }}</option>
+          </select>
+        </div>
+        <div class="form-group">
           <label>Plan de Prueba</label>
           <select class="form-control" [(ngModel)]="form.test_plan_id" name="plan">
             <option [ngValue]="null">--</option>
@@ -78,6 +87,7 @@ export class TestCaseFormComponent {
   @Output() cancel = new EventEmitter<void>();
 
   plans: TestPlan[] = [];
+  actors: Actor[] = [];
 
   form: TestCreate = {
     name: '',
@@ -87,11 +97,20 @@ export class TestCaseFormComponent {
     then: '',
     priority: '',
     status: '',
-    test_plan_id: undefined
+    test_plan_id: undefined,
+    actor_id: undefined
   };
 
-  constructor(private service: TestCaseService, private api: ApiService) {
+  constructor(
+    private service: TestCaseService,
+    private api: ApiService,
+    private actorsService: ActorService,
+    private workspace: WorkspaceService
+  ) {
     this.api.getTestPlans().subscribe(pl => this.plans = pl);
+    if (this.workspace.clientId) {
+      this.actorsService.getActors(this.workspace.clientId).subscribe(a => (this.actors = a));
+    }
   }
 
   ngOnChanges() {
@@ -106,7 +125,8 @@ export class TestCaseFormComponent {
         then: '',
         priority: '',
         status: '',
-        test_plan_id: undefined
+        test_plan_id: undefined,
+        actor_id: undefined
       };
     }
   }

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -44,6 +44,7 @@ export interface Test {
   when?: string;
   then?: string;
   test_plan_id?: number;
+  actor_id?: number;
 }
 
 export interface TestPlan {
@@ -159,6 +160,7 @@ export interface TestCreate {
   when?: string;
   then?: string;
   test_plan_id?: number;
+  actor_id?: number;
 }
 
 export interface TestPlanCreate {


### PR DESCRIPTION
## Summary
- add `actor_id` to backend test cases
- search tests by name or description
- include actor selection in test case form
- create script management component with parameterization dialog
- expose new `scripts` route in frontend

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6854968fd3dc832fbf01d24520dd2306