### PR TITLE
Add reusable mobile-first UI components

### DIFF
--- a/frontend/src/app/components/ui/floating-action-button.component.ts
+++ b/frontend/src/app/components/ui/floating-action-button.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface FabAction {
+  label: string;
+  action: () => void;
+}
+
+@Component({
+  selector: 'app-floating-action-button',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="menu" *ngIf="expanded">
+      <button *ngFor="let a of actions" (click)="a.action()">{{ a.label }}</button>
+    </div>
+    <button class="fab" (click)="toggle()">+</button>
+  `,
+  styles: [`
+    :host { position:fixed; bottom:1rem; right:1rem; z-index:1000; container-type:inline-size; }
+    .fab { width:56px; height:56px; border-radius:50%; border:none; background:var(--btn-primary); color:var(--btn-primary-text); display:flex; align-items:center; justify-content:center; font-size:2rem; box-shadow:0 2px 8px rgba(0,0,0,0.3); }
+    .menu { position:absolute; bottom:70px; right:0; display:flex; flex-direction:column; gap:0.5rem; }
+    .menu button { border:none; padding:0.5rem 1rem; border-radius:4px; background:var(--panel-bg); color:var(--title-color); box-shadow:0 2px 4px rgba(0,0,0,0.2); }
+    @container (min-width:768px) { :host { position:static; } }
+  `]
+})
+export class FloatingActionButtonComponent {
+  @Input() actions: FabAction[] = [];
+  expanded = false;
+
+  toggle() { this.expanded = !this.expanded; }
+}

--- a/frontend/src/app/components/ui/progress-indicator.component.ts
+++ b/frontend/src/app/components/ui/progress-indicator.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-progress-indicator',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="progress-indicator">
+      <div class="step" *ngFor="let s of steps; let i = index" [class.active]="i <= current">
+        <span class="circle">{{ i + 1 }}</span>
+        <span class="label">{{ s }}</span>
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host { display:block; container-type:inline-size; }
+    .progress-indicator { display:flex; flex-direction:column; gap:0.5rem; }
+    .step { display:flex; align-items:center; gap:0.5rem; color:var(--secondary-text); }
+    .circle { width:1.5rem; height:1.5rem; border-radius:50%; background:var(--checkbox-color); color:var(--panel-bg); display:flex; align-items:center; justify-content:center; font-size:0.8rem; }
+    .step.active .circle { background:var(--btn-primary); }
+    .step.active { color:var(--title-color); }
+    @container (min-width:768px) { .progress-indicator { flex-direction:row; } }
+  `]
+})
+export class ProgressIndicatorComponent {
+  @Input() steps: string[] = [];
+  @Input() current = 0;
+}

--- a/frontend/src/app/components/ui/responsive-form.component.ts
+++ b/frontend/src/app/components/ui/responsive-form.component.ts
@@ -1,0 +1,61 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+
+export interface FormField {
+  label: string;
+  name: string;
+  type?: string;
+  required?: boolean;
+}
+
+@Component({
+  selector: 'app-responsive-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
+      <div class="form-field" *ngFor="let f of fields">
+        <input [type]="f.type || 'text'" [formControlName]="f.name" [id]="f.name" placeholder=" " [required]="f.required">
+        <label [for]="f.name">{{ f.label }}</label>
+        <div class="error" *ngIf="form.get(f.name)?.invalid && form.get(f.name)?.touched">Campo requerido</div>
+      </div>
+      <ng-content></ng-content>
+    </form>
+  `,
+  styles: [`
+    :host { display:block; container-type:inline-size; }
+    form { display:flex; flex-wrap:wrap; gap:var(--gap,1rem); }
+    .form-field { position:relative; flex:1 1 100%; }
+    .form-field input { width:100%; padding:0.75rem; border:1px solid var(--border-color); border-radius:4px; background:var(--input-bg); }
+    .form-field label { position:absolute; left:0.75rem; top:0.75rem; color:var(--secondary-text); transition:0.2s; pointer-events:none; }
+    .form-field input:focus + label,
+    .form-field input:not(:placeholder-shown) + label { transform:translateY(-1.2rem) scale(0.85); background:var(--panel-bg); padding:0 0.25rem; }
+    .error { color:#dc3545; font-size:0.8rem; margin-top:0.25rem; }
+    @container (min-width:600px) { .form-field { flex:1 0 calc(50% - var(--gap,1rem)); } }
+  `]
+})
+export class ResponsiveFormComponent {
+  @Input() fields: FormField[] = [];
+  @Output() submitted = new EventEmitter<any>();
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({});
+  }
+
+  ngOnChanges() {
+    const group: any = {};
+    for (const f of this.fields) {
+      group[f.name] = f.required ? ['', Validators.required] : [''];
+    }
+    this.form = this.fb.group(group);
+  }
+
+  submit() {
+    this.form.markAllAsTouched();
+    if (this.form.valid) {
+      this.submitted.emit(this.form.value);
+    }
+  }
+}

--- a/frontend/src/app/components/ui/responsive-grid.component.ts
+++ b/frontend/src/app/components/ui/responsive-grid.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input, HostBinding } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-responsive-grid',
+  standalone: true,
+  imports: [CommonModule],
+  template: `<div class="grid"><ng-content></ng-content></div>`,
+  styles: [`
+    :host { display:block; container-type:inline-size; }
+    .grid { display:grid; gap:var(--gap,1rem); grid-template-columns:repeat(var(--cols-mobile,1),1fr); }
+    @container (min-width:600px) { .grid { grid-template-columns:repeat(var(--cols-tablet,2),1fr); } }
+    @container (min-width:900px) { .grid { grid-template-columns:repeat(var(--cols-desktop,4),1fr); } }
+  `]
+})
+export class ResponsiveGridComponent {
+  @Input() mobileCols = 1;
+  @Input() tabletCols = 2;
+  @Input() desktopCols = 4;
+  @Input() gap = '1rem';
+
+  @HostBinding('style.--cols-mobile') get colsMobile() { return this.mobileCols; }
+  @HostBinding('style.--cols-tablet') get colsTablet() { return this.tabletCols; }
+  @HostBinding('style.--cols-desktop') get colsDesktop() { return this.desktopCols; }
+  @HostBinding('style.--gap') get hostGap() { return this.gap; }
+}

--- a/frontend/src/app/components/ui/responsive-table.component.ts
+++ b/frontend/src/app/components/ui/responsive-table.component.ts
@@ -1,0 +1,60 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface TableColumn {
+  label: string;
+  key: string;
+}
+
+@Component({
+  selector: 'app-responsive-table',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <ng-container *ngIf="data?.length; else empty">
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th *ngFor="let c of columns">{{ c.label }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let row of data">
+              <td *ngFor="let c of columns">{{ row[c.key] }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="card-list">
+        <div class="card" *ngFor="let row of data">
+          <div class="card-item" *ngFor="let c of columns">
+            <strong>{{ c.label }}:</strong> {{ row[c.key] }}
+          </div>
+        </div>
+      </div>
+    </ng-container>
+    <ng-template #empty>
+      <p>No data</p>
+    </ng-template>
+  `,
+  styles: [`
+    :host { display:block; container-type:inline-size; width:100%; }
+    .table-wrapper { display:none; }
+    .card { border:1px solid var(--border-color); padding:1rem; margin-bottom:1rem; border-radius:8px; background:var(--panel-bg); }
+    .card-item { margin:0.25rem 0; }
+    @container (min-width:600px) {
+      .table-wrapper { display:block; overflow-x:auto; }
+      table { width:100%; border-collapse:collapse; }
+      th, td { padding:0.5rem; border-bottom:1px solid var(--border-color); }
+      .card-list { display:none; }
+    }
+    @container (min-width:900px) {
+      .table-wrapper { overflow:visible; }
+    }
+  `]
+})
+export class ResponsiveTableComponent {
+  @Input() columns: TableColumn[] = [];
+  @Input() data: any[] = [];
+}

--- a/frontend/src/app/components/ui/swipeable-cards.component.ts
+++ b/frontend/src/app/components/ui/swipeable-cards.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-swipeable-cards',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="container" (pointerdown)="start($event)" (pointerup)="end($event)">
+      <div class="cards" [style.transform]="'translateX(' + (-current * 100) + '%)'">
+        <ng-content></ng-content>
+      </div>
+    </div>
+    <div class="controls" *ngIf="isDesktop">
+      <button (click)="prev()" [disabled]="current===0">Prev</button>
+      <button (click)="next()" [disabled]="current===count-1">Next</button>
+    </div>
+  `,
+  styles: [`
+    :host { display:block; container-type:inline-size; }
+    .container { overflow:hidden; touch-action:pan-y; }
+    .cards { display:flex; transition:transform 0.3s ease; }
+    ::ng-deep > * { flex:0 0 100%; }
+    .controls { margin-top:0.5rem; display:flex; gap:0.5rem; justify-content:center; }
+    button { padding:0.5rem 1rem; border:none; border-radius:4px; background:var(--btn-primary); color:var(--btn-primary-text); }
+    @container (min-width:768px) { .container { touch-action:auto; } }
+  `]
+})
+export class SwipeableCardsComponent {
+  @Input() count = 0;
+  current = 0;
+  private startX = 0;
+  isDesktop = false;
+
+  ngOnInit() { this.isDesktop = window.innerWidth >= 768; }
+
+  start(event: PointerEvent) { this.startX = event.clientX; }
+  end(event: PointerEvent) {
+    const diff = event.clientX - this.startX;
+    if (Math.abs(diff) > 50) {
+      if (diff < 0) this.next(); else this.prev();
+    }
+  }
+  next() { if (this.current < this.count - 1) this.current++; }
+  prev() { if (this.current > 0) this.current--; }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,5 +1,6 @@
 /* Variables de colores según especificaciones */
 :root {
+  color-scheme: light dark;
   --bg-general: #E6F0FA;
   --bg-general-alt: #D9EBFF;
   --panel-bg: #FFFFFF;
@@ -12,6 +13,23 @@
   --input-text: #555555;
   --checkbox-color: #CCCCCC;
   --secondary-text: #666666;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-general: #121212;
+    --bg-general-alt: #1e1e1e;
+    --panel-bg: #1a1a1a;
+    --btn-primary: #3399ff;
+    --btn-primary-text: #ffffff;
+    --title-color: #f5f5f5;
+    --subtitle-color: #cccccc;
+    --input-bg: #2a2a2a;
+    --border-color: #444444;
+    --input-text: #eeeeee;
+    --checkbox-color: #666666;
+    --secondary-text: #bbbbbb;
+  }
 }
 
 /* Reset y configuración base */


### PR DESCRIPTION
## Summary
- implement ResponsiveTable for card/table view
- implement ResponsiveForm with floating labels
- implement ResponsiveGrid with container queries
- implement FloatingActionButton with expandable menu
- implement SwipeableCards with gesture navigation
- implement ProgressIndicator with vertical/horizontal modes
- add automatic dark/light theme variables

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6854a36636c4832f9d20ffb4d0a86f46