### PR TITLE
Implement basic data management system

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,5 @@
-# Package init
+"""Backend utilities."""
+
+from .data_factory import DataFactory
+
+__all__ = ["DataFactory"]

--- a/backend/app/data_factory.py
+++ b/backend/app/data_factory.py
@@ -1,0 +1,60 @@
+import csv
+import json
+import random
+import time
+from pathlib import Path
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+class DataFactory:
+    """Utility to generate or import data objects."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def _get_pool(self, type_: str, env: str) -> models.DataPool:
+        pool = (
+            self.db.query(models.DataPool)
+            .filter(models.DataPool.type == type_, models.DataPool.environment == env)
+            .first()
+        )
+        if not pool:
+            pool = models.DataPool(type=type_, environment=env)
+            self.db.add(pool)
+            self.db.commit()
+            self.db.refresh(pool)
+        return pool
+
+    def import_csv(self, csv_path: Path, type_: str, env: str) -> None:
+        pool = self._get_pool(type_, env)
+        with csv_path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                obj = models.TestDataObject(
+                    pool_id=pool.id,
+                    data=json.dumps(row),
+                    state=models.DataState.NEW.value,
+                )
+                self.db.add(obj)
+        self.db.commit()
+
+    def generate(self, type_: str, env: str, rules: dict[str, str], count: int = 1) -> None:
+        pool = self._get_pool(type_, env)
+        for _ in range(count):
+            data = {k: self._resolve_rule(v) for k, v in rules.items()}
+            obj = models.TestDataObject(
+                pool_id=pool.id,
+                data=json.dumps(data),
+                state=models.DataState.NEW.value,
+            )
+            self.db.add(obj)
+        self.db.commit()
+
+    def _resolve_rule(self, rule: str) -> str:
+        if rule == "{{timestamp}}":
+            return str(int(time.time()))
+        if rule == "{{random}}":
+            return str(random.randint(1000, 9999))
+        return rule

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, root_validator
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from datetime import date, datetime
 
 
@@ -407,3 +407,29 @@ class ExecutionSchedule(ExecutionScheduleBase):
 
     class Config:
         orm_mode = True
+
+
+class DataObjectBase(BaseModel):
+    pool_id: int
+    data: Dict[str, Any]
+
+
+class DataObject(DataObjectBase):
+    id: int
+    state: str
+
+    class Config:
+        orm_mode = True
+
+
+class DataObjectHistory(BaseModel):
+    id: int
+    action: str
+    timestamp: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class DataObjectAction(BaseModel):
+    id: int

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -1,4 +1,6 @@
 import json
+import random
+import time
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +18,14 @@ class DataFactory:
         with path.open() as f:
             self.data: dict[str, Any] = json.load(f)
 
+    def _resolve(self, value: str) -> str:
+        if "{{timestamp}}" in value:
+            value = value.replace("{{timestamp}}", str(int(time.time())))
+        if "{{random}}" in value:
+            value = value.replace("{{random}}", str(random.randint(1000, 9999)))
+        return value
+
     def get_user(self, index: int = 0) -> UserData:
         user = self.data.get("users", [])[index]
+        user = {k: self._resolve(v) if isinstance(v, str) else v for k, v in user.items()}
         return UserData(**user)

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -4,3 +4,23 @@ from dataclasses import dataclass
 class UserData:
     username: str
     password: str
+
+
+@dataclass
+class BaseTestData:
+    timestamp: str
+
+
+@dataclass
+class WebTestData(BaseTestData):
+    browser: str
+
+
+@dataclass
+class APITestData(BaseTestData):
+    token: str
+
+
+@dataclass
+class MobileTestData(BaseTestData):
+    device: str

--- a/tests/pools/qa.json
+++ b/tests/pools/qa.json
@@ -1,0 +1,6 @@
+{
+  "users": [
+    {"username": "qa_{{timestamp}}_{{random}}", "password": "qa_pass"}
+  ],
+  "base_url": "https://qa.example.com"
+}

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -1,0 +1,49 @@
+import os
+import json
+import tempfile
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app import models
+
+Base.metadata.create_all(bind=engine)
+
+client = TestClient(app)
+
+
+def setup_pool():
+    db = SessionLocal()
+    pool = models.DataPool(type="user", environment="QA")
+    db.add(pool)
+    db.commit()
+    db.refresh(pool)
+    obj = models.TestDataObject(pool_id=pool.id, data=json.dumps({"u":"x"}), state=models.DataState.NEW.value)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    db.close()
+    return obj.id
+
+
+def test_data_object_lifecycle():
+    obj_id = setup_pool()
+    resp = client.get("/data-objects", params={"type": "user", "environment": "QA", "state": "available"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.post("/data-objects/reserve", json={"id": obj_id})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "bloqueado"
+
+    resp = client.post("/data-objects/release", json={"id": obj_id})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "usado"
+
+    resp = client.get(f"/data-objects/{obj_id}/history")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2

--- a/tests/test_data_factory.py
+++ b/tests/test_data_factory.py
@@ -1,0 +1,12 @@
+import os
+from .context import load_context
+from .data_factory import DataFactory
+
+
+def test_dynamic_placeholders():
+    os.environ["TEST_ENV"] = "qa"
+    ctx = load_context()
+    factory = DataFactory(env=ctx.env)
+    user = factory.get_user()
+    assert user.username.startswith("qa_")
+    assert user.password == "qa_pass"


### PR DESCRIPTION
## Summary
- expand models with DataPool and TestDataObject
- add DataFactory utility for pools and generation
- expose new `/data-objects` API endpoints
- support dynamic variables in test DataFactory
- add QA data pool and new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a8151468832f9dbb8599f6eeca2e