### PR TITLE
Add environment management models and API

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -368,3 +368,66 @@ class DataObjectHistory(Base):
     timestamp = Column(DateTime, nullable=False, default=datetime.utcnow)
 
     obj = relationship("TestDataObject", back_populates="history")
+
+
+# -----------------------------------------------------
+# Environment management models
+# -----------------------------------------------------
+
+class EnvironmentType(str, enum.Enum):
+    QA = "QA"
+    UAT = "UAT"
+    PREPROD = "PREPROD"
+    PROD = "PROD"
+
+
+class Environment(Base):
+    __tablename__ = "environments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
+    name = Column(String, nullable=False)
+    capacity_limit = Column(Integer, nullable=True)
+    is_active = Column(Boolean, default=True)
+
+    project = relationship("Project", backref="environments")
+    config = relationship(
+        "EnvironmentConfig", uselist=False, back_populates="environment"
+    )
+    credentials = relationship(
+        "EnvironmentCredential", uselist=False, back_populates="environment"
+    )
+    schedules = relationship("EnvironmentSchedule", back_populates="environment")
+
+
+class EnvironmentConfig(Base):
+    __tablename__ = "environment_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    environment_id = Column(Integer, ForeignKey("environments.id"), nullable=False)
+    settings = Column(String, nullable=True)
+
+    environment = relationship("Environment", back_populates="config")
+
+
+class EnvironmentCredential(Base):
+    __tablename__ = "environment_credentials"
+
+    id = Column(Integer, primary_key=True, index=True)
+    environment_id = Column(Integer, ForeignKey("environments.id"), nullable=False)
+    username = Column(String, nullable=False)
+    password = Column(String, nullable=False)
+
+    environment = relationship("Environment", back_populates="credentials")
+
+
+class EnvironmentSchedule(Base):
+    __tablename__ = "environment_schedules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    environment_id = Column(Integer, ForeignKey("environments.id"), nullable=False)
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=False)
+    blackout = Column(Boolean, default=False)
+
+    environment = relationship("Environment", back_populates="schedules")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -433,3 +433,59 @@ class DataObjectHistory(BaseModel):
 
 class DataObjectAction(BaseModel):
     id: int
+
+
+class EnvironmentConfigBase(BaseModel):
+    settings: Optional[str] = None
+
+
+class EnvironmentConfig(EnvironmentConfigBase):
+    id: int
+    environment_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class EnvironmentCredentialBase(BaseModel):
+    username: str
+    password: str
+
+
+class EnvironmentCredential(EnvironmentCredentialBase):
+    id: int
+    environment_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class EnvironmentScheduleBase(BaseModel):
+    start_time: datetime
+    end_time: datetime
+    blackout: bool = False
+
+
+class EnvironmentSchedule(EnvironmentScheduleBase):
+    id: int
+    environment_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class EnvironmentBase(BaseModel):
+    project_id: int
+    name: str
+    capacity_limit: Optional[int] = None
+    is_active: bool = True
+
+
+class Environment(EnvironmentBase):
+    id: int
+    config: Optional[EnvironmentConfig] = None
+    credentials: Optional[EnvironmentCredential] = None
+    schedules: List[EnvironmentSchedule] = []
+
+    class Config:
+        orm_mode = True

--- a/tests/test_environment_api.py
+++ b/tests/test_environment_api.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app import models
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def setup_env() -> tuple[int, int]:
+    db: Session = SessionLocal()
+    client_obj = models.Client(name="c")
+    db.add(client_obj)
+    db.commit()
+    db.refresh(client_obj)
+    project = models.Project(name="p", client_id=client_obj.id)
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    env = models.Environment(project_id=project.id, name=models.EnvironmentType.QA.value)
+    db.add(env)
+    db.commit()
+    db.refresh(env)
+    window = models.EnvironmentSchedule(
+        environment_id=env.id,
+        start_time=datetime.utcnow() - timedelta(hours=1),
+        end_time=datetime.utcnow() + timedelta(hours=1),
+        blackout=False,
+    )
+    db.add(window)
+    db.commit()
+    env_id = env.id
+    project_id = project.id
+    db.close()
+    return env_id, project_id
+
+
+def test_environment_endpoints():
+    env_id, project_id = setup_env()
+
+    resp = client.get(f"/environments/{project_id}")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.put(
+        f"/environments/{env_id}/credentials",
+        json={"username": "user", "password": "Passw0rd!"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(f"/environments/{env_id}/availability")
+    assert resp.status_code == 200
+    assert resp.json()["available"] is True
+
+    resp = client.post(f"/environments/{env_id}/promote")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == models.EnvironmentType.UAT.value


### PR DESCRIPTION
## Summary
- extend SQLAlchemy models with environment management
- provide new pydantic schemas
- implement `/environments` endpoints for credentials, promotion and availability
- add automated tests for new API

## Testing
- `pylint $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a94f7ec0832fb9651553fe4a4633