### PR TITLE
Implement marketplace endpoints and basic Angular view

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Para conocer los detalles de instalación y uso del backend revisa `backend/READ
 La carpeta `postman` se genera automáticamente ejecutando `python generate_postman.py` y
 contiene una colección lista para importar en Postman y probar todos los endpoints.
 - `historias_bdd` para la trazabilidad a BDD
+- Marketplace de componentes disponible en `/marketplace/components/`
 - 
 ## Autenticación
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -431,3 +431,15 @@ class EnvironmentSchedule(Base):
     blackout = Column(Boolean, default=False)
 
     environment = relationship("Environment", back_populates="schedules")
+
+
+class MarketplaceComponent(Base):
+    __tablename__ = "marketplace_components"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    code = Column(String, nullable=False)
+    version = Column(String, nullable=False, default="0.1.0")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2520,3 +2520,52 @@ def promote_environment(env_id: int, db: Session = Depends(deps.get_db)):
     db.commit()
     db.refresh(env)
     return env
+
+
+# -----------------------------------------------------
+# Marketplace endpoints
+# -----------------------------------------------------
+
+
+@router.post("/marketplace/components/", response_model=schemas.MarketplaceComponent)
+def create_component(component: schemas.MarketplaceComponentCreate, db: Session = Depends(deps.get_db)):
+    db_obj = models.MarketplaceComponent(**component.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/marketplace/components/", response_model=list[schemas.MarketplaceComponent])
+def read_components(skip: int = 0, limit: int = 10, db: Session = Depends(deps.get_db)):
+    return db.query(models.MarketplaceComponent).offset(skip).limit(limit).all()
+
+
+@router.get("/marketplace/components/{component_id}", response_model=schemas.MarketplaceComponent)
+def read_component(component_id: int, db: Session = Depends(deps.get_db)):
+    comp = db.query(models.MarketplaceComponent).filter(models.MarketplaceComponent.id == component_id).first()
+    if not comp:
+        raise HTTPException(status_code=404, detail="Component not found")
+    return comp
+
+
+@router.put("/marketplace/components/{component_id}", response_model=schemas.MarketplaceComponent)
+def update_component(component_id: int, component_in: schemas.MarketplaceComponentCreate, db: Session = Depends(deps.get_db)):
+    comp = db.query(models.MarketplaceComponent).filter(models.MarketplaceComponent.id == component_id).first()
+    if not comp:
+        raise HTTPException(status_code=404, detail="Component not found")
+    for field, value in component_in.dict().items():
+        setattr(comp, field, value)
+    db.commit()
+    db.refresh(comp)
+    return comp
+
+
+@router.delete("/marketplace/components/{component_id}")
+def delete_component(component_id: int, db: Session = Depends(deps.get_db)):
+    comp = db.query(models.MarketplaceComponent).filter(models.MarketplaceComponent.id == component_id).first()
+    if not comp:
+        raise HTTPException(status_code=404, detail="Component not found")
+    db.delete(comp)
+    db.commit()
+    return {"ok": True}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -489,3 +489,23 @@ class Environment(EnvironmentBase):
 
     class Config:
         orm_mode = True
+
+
+class MarketplaceComponentBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    code: str
+    version: str = "0.1.0"
+
+
+class MarketplaceComponentCreate(MarketplaceComponentBase):
+    pass
+
+
+class MarketplaceComponent(MarketplaceComponentBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -33,6 +33,7 @@ export const routes: Routes = [
       { path: 'elements', loadComponent: () => import('./components/elements/elements.component').then(m => m.ElementsComponent) },
       { path: 'actions', loadComponent: () => import('./components/actions/actions.component').then(m => m.ActionsComponent) },
       { path: 'agents', loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent) },
+      { path: 'marketplace', loadComponent: () => import('./components/marketplace/marketplace.component').then(m => m.MarketplaceComponent) },
       { path: 'projects', loadComponent: () => import('./components/client-admin/client-projects.component').then(m => m.ClientProjectsComponent) },
       { path: 'service-manager', loadComponent: () => import('./components/service-manager/service-manager.component').then(m => m.ServiceManagerComponent) },
       { path: 'client-admin', loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent) },

--- a/frontend/src/app/components/marketplace/component-form.component.ts
+++ b/frontend/src/app/components/marketplace/component-form.component.ts
@@ -1,0 +1,67 @@
+import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MarketplaceComponent, MarketplaceComponentCreate } from '../../models';
+import { MarketplaceService } from '../../services/marketplace.service';
+
+@Component({
+  selector: 'app-component-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="component-form">
+      <h2>{{ component ? 'Editar' : 'Crear' }} Componente</h2>
+      <form (ngSubmit)="submit()">
+        <div class="form-group">
+          <label>Nombre</label>
+          <input class="form-control" [(ngModel)]="form.name" name="name" required>
+        </div>
+        <div class="form-group">
+          <label>Descripción</label>
+          <textarea class="form-control" [(ngModel)]="form.description" name="description"></textarea>
+        </div>
+        <div class="form-group">
+          <label>Versión</label>
+          <input class="form-control" [(ngModel)]="form.version" name="version">
+        </div>
+        <div class="form-group">
+          <label>Código</label>
+          <textarea class="form-control" [(ngModel)]="form.code" name="code" rows="5" required></textarea>
+        </div>
+        <div class="mt-3">
+          <button type="submit" class="btn btn-primary mr-2">Guardar</button>
+          <button type="button" class="btn btn-secondary" (click)="cancel.emit()">Cancelar</button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .component-form { padding: 1rem; }
+    .form-group { margin-bottom: 1rem; }
+    .mr-2 { margin-right: 0.5rem; }
+  `]
+})
+export class ComponentFormComponent implements OnChanges {
+  @Input() component: MarketplaceComponent | null = null;
+  @Output() saved = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  form: MarketplaceComponentCreate = { name: '', description: '', code: '', version: '0.1.0' };
+
+  constructor(private service: MarketplaceService) {}
+
+  ngOnChanges() {
+    if (this.component) {
+      this.form = { name: this.component.name, description: this.component.description, code: this.component.code, version: this.component.version };
+    } else {
+      this.form = { name: '', description: '', code: '', version: '0.1.0' };
+    }
+  }
+
+  submit() {
+    const obs = this.component ?
+      this.service.updateComponent(this.component.id, this.form) :
+      this.service.createComponent(this.form);
+    obs.subscribe(() => this.saved.emit());
+  }
+}

--- a/frontend/src/app/components/marketplace/marketplace.component.ts
+++ b/frontend/src/app/components/marketplace/marketplace.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MarketplaceComponent as Item } from '../../models';
+import { MarketplaceService } from '../../services/marketplace.service';
+import { ComponentFormComponent } from './component-form.component';
+
+@Component({
+  selector: 'app-marketplace',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ComponentFormComponent],
+  template: `
+    <div class="main-panel">
+      <h1>Marketplace</h1>
+      <div class="mb-3">
+        <button class="btn btn-primary" (click)="new()">Nuevo</button>
+      </div>
+      <table class="table table-bordered" *ngIf="components.length > 0">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Versión</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let c of components">
+            <td>{{ c.name }}</td>
+            <td>{{ c.version }}</td>
+            <td>
+              <button class="btn btn-sm btn-secondary mr-2" (click)="edit(c)">Editar</button>
+              <button class="btn btn-sm btn-danger" (click)="remove(c)">Eliminar</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div *ngIf="components.length === 0">No hay componentes.</div>
+
+      <app-component-form *ngIf="showForm" [component]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-component-form>
+    </div>
+  `,
+  styles: [`
+    .mr-2 { margin-right: 0.25rem; }
+  `]
+})
+export class MarketplaceComponent implements OnInit {
+  components: Item[] = [];
+  showForm = false;
+  editing: Item | null = null;
+
+  constructor(private service: MarketplaceService) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.service.getComponents().subscribe(c => this.components = c);
+  }
+
+  new() {
+    this.editing = null;
+    this.showForm = true;
+  }
+
+  edit(c: Item) {
+    this.editing = c;
+    this.showForm = true;
+  }
+
+  remove(c: Item) {
+    if (confirm('¿Eliminar componente?')) {
+      this.service.deleteComponent(c.id).subscribe(() => this.load());
+    }
+  }
+
+  onSaved() {
+    this.showForm = false;
+    this.load();
+  }
+}

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -256,6 +256,23 @@ export interface LoginResponse {
   token_type: string;
 }
 
+export interface MarketplaceComponent {
+  id: number;
+  name: string;
+  description?: string;
+  code: string;
+  version: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MarketplaceComponentCreate {
+  name: string;
+  description?: string;
+  code: string;
+  version?: string;
+}
+
 export interface ApiResponse<T> {
   data?: T;
   error?: string;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -9,7 +9,8 @@ import {
   UserCreate, RoleCreate, ClientCreate, ProjectCreate, TestCreate,
   TestPlanCreate, PageCreate, PageElementCreate, ActionCreate,
   ActionAssignmentCreate, Actor, ActorCreate, AgentCreate, ExecutionPlanCreate,
-  LoginRequest, LoginResponse, UserRoleUpdate, PendingExecution
+  LoginRequest, LoginResponse, UserRoleUpdate, PendingExecution,
+  MarketplaceComponent, MarketplaceComponentCreate
 } from '../models';
 
 @Injectable({
@@ -453,6 +454,23 @@ export class ApiService {
 
   getDashboardMetrics(): Observable<any> {
     return this.http.get(`${this.baseUrl}/metrics/dashboard`, { headers: this.getHeaders() });
+  }
+
+  // Marketplace
+  getMarketplaceComponents(): Observable<MarketplaceComponent[]> {
+    return this.http.get<MarketplaceComponent[]>(`${this.baseUrl}/marketplace/components/`, { headers: this.getHeaders() });
+  }
+
+  createMarketplaceComponent(c: MarketplaceComponentCreate): Observable<MarketplaceComponent> {
+    return this.http.post<MarketplaceComponent>(`${this.baseUrl}/marketplace/components/`, c, { headers: this.getHeaders() });
+  }
+
+  updateMarketplaceComponent(id: number, c: MarketplaceComponentCreate): Observable<MarketplaceComponent> {
+    return this.http.put<MarketplaceComponent>(`${this.baseUrl}/marketplace/components/${id}`, c, { headers: this.getHeaders() });
+  }
+
+  deleteMarketplaceComponent(id: number): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/marketplace/components/${id}`, { headers: this.getHeaders() });
   }
 
   isAuthenticated(): boolean {

--- a/frontend/src/app/services/marketplace.service.ts
+++ b/frontend/src/app/services/marketplace.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { MarketplaceComponent, MarketplaceComponentCreate } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class MarketplaceService {
+  constructor(private api: ApiService) {}
+
+  getComponents(): Observable<MarketplaceComponent[]> {
+    return this.api.getMarketplaceComponents();
+  }
+
+  createComponent(c: MarketplaceComponentCreate): Observable<MarketplaceComponent> {
+    return this.api.createMarketplaceComponent(c);
+  }
+
+  updateComponent(id: number, c: MarketplaceComponentCreate): Observable<MarketplaceComponent> {
+    return this.api.updateMarketplaceComponent(id, c);
+  }
+
+  deleteComponent(id: number): Observable<any> {
+    return this.api.deleteMarketplaceComponent(id);
+  }
+}

--- a/tests/test_marketplace_api.py
+++ b/tests/test_marketplace_api.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def test_marketplace_crud():
+    resp = client.post(
+        "/marketplace/components/",
+        json={"name": "Comp", "description": "d", "code": "print('hi')", "version": "1.0"},
+    )
+    assert resp.status_code == 200
+    comp_id = resp.json()["id"]
+
+    resp = client.get("/marketplace/components/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.put(
+        f"/marketplace/components/{comp_id}",
+        json={"name": "Comp", "description": "d", "code": "print('x')", "version": "1.1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["version"] == "1.1"
+
+    resp = client.delete(f"/marketplace/components/{comp_id}")
+    assert resp.status_code == 200
+
+    resp = client.get("/marketplace/components/")
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- add bullet for new marketplace endpoints in README
- define `MarketplaceComponent` model and schemas
- implement CRUD routes for `/marketplace/components/`
- expose marketplace in Angular via new service and components
- add route `marketplace` in front-end router
- include simple API tests for marketplace endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ab745de8832fbd150cdfefab4c93