### PR TITLE
Add Jira integration preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ contiene una colección lista para importar en Postman y probar todos los endpoi
 ## Autenticación
 
 Regístrate enviando un POST a `/users/` con `username` y `password`. El login se realiza en `/token` utilizando un formulario `application/x-www-form-urlencoded`.
+
+## Integraciones externas
+
+La API incluye endpoints de vista previa para conectarse con Jira u otros servicios que acepten peticiones HTTP. Con una cuenta gratuita puedes:
+
+- Crear incidencias con `POST /integrations/jira/issue`.
+- Cambiar su estado mediante `POST /integrations/jira/issues/{issue_key}/status`.
+- Lanzar pipelines externos desde `POST /integrations/jira/pipeline`.
+
+Configura las variables `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` y `JIRA_PROJECT_KEY` para habilitar estas integraciones.
+

--- a/backend/README2.md
+++ b/backend/README2.md
@@ -225,3 +225,14 @@ Se crearán los archivos `postman/collection.json` y `postman/environment.json`
 que puedes importar directamente en Postman. La colección contiene ejemplos de
 cada endpoint y variables de entorno como `base_url` y `token` para que puedas
 ejecutar las peticiones rápidamente.
+
+## Integración con Jira
+
+Existe un cliente básico para Jira que permite crear issues, transicionar su estado y lanzar pipelines externos. Los endpoints disponibles son:
+
+- `POST /integrations/jira/issue`
+- `POST /integrations/jira/issues/{issue_key}/status`
+- `POST /integrations/jira/pipeline`
+
+Configura las variables `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` y `JIRA_PROJECT_KEY` antes de usar estas llamadas.
+

--- a/backend/app/integrations.py
+++ b/backend/app/integrations.py
@@ -1,0 +1,45 @@
+import os
+import requests
+
+
+class JiraIntegration:
+    """Simple Jira REST API client for basic operations."""
+
+    def __init__(self) -> None:
+        self.base_url = os.getenv("JIRA_BASE_URL", "")
+        self.email = os.getenv("JIRA_EMAIL")
+        self.api_token = os.getenv("JIRA_API_TOKEN")
+        self.project_key = os.getenv("JIRA_PROJECT_KEY")
+        if self.base_url and not self.base_url.endswith("/"):
+            self.base_url += "/"
+
+    def _auth(self) -> tuple[str, str]:
+        if not self.email or not self.api_token:
+            raise RuntimeError("Jira credentials not configured")
+        return self.email, self.api_token
+
+    def create_issue(self, summary: str, description: str | None = None) -> dict:
+        url = f"{self.base_url}rest/api/2/issue"
+        payload = {
+            "fields": {
+                "project": {"key": self.project_key},
+                "summary": summary,
+                "description": description or "",
+                "issuetype": {"name": "Task"},
+            }
+        }
+        response = requests.post(url, json=payload, auth=self._auth(), timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def transition_issue(self, issue_key: str, transition_id: str) -> bool:
+        url = f"{self.base_url}rest/api/2/issue/{issue_key}/transitions"
+        payload = {"transition": {"id": transition_id}}
+        response = requests.post(url, json=payload, auth=self._auth(), timeout=10)
+        response.raise_for_status()
+        return True
+
+    def trigger_pipeline(self, pipeline_url: str) -> bool:
+        response = requests.post(pipeline_url, auth=self._auth(), timeout=10)
+        response.raise_for_status()
+        return True

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2520,3 +2520,44 @@ def promote_environment(env_id: int, db: Session = Depends(deps.get_db)):
     db.commit()
     db.refresh(env)
     return env
+
+from .integrations import JiraIntegration
+
+@router.post("/integrations/jira/issue")
+def create_jira_issue(
+    issue: schemas.JiraIssueCreate,
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    client = JiraIntegration()
+    try:
+        return client.create_issue(issue.summary, issue.description)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/integrations/jira/issues/{issue_key}/status")
+def transition_jira_issue(
+    issue_key: str,
+    data: schemas.JiraTransition,
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    client = JiraIntegration()
+    try:
+        client.transition_issue(issue_key, data.transition_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"ok": True}
+
+
+@router.post("/integrations/jira/pipeline")
+def trigger_jira_pipeline(
+    info: schemas.PipelineTrigger,
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    client = JiraIntegration()
+    try:
+        client.trigger_pipeline(info.url)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"ok": True}
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -489,3 +489,16 @@ class Environment(EnvironmentBase):
 
     class Config:
         orm_mode = True
+
+class JiraIssueCreate(BaseModel):
+    summary: str
+    description: Optional[str] = None
+
+
+class JiraTransition(BaseModel):
+    issue_key: str
+    transition_id: str
+
+
+class PipelineTrigger(BaseModel):
+    url: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ python-multipart
 weasyprint
 matplotlib
 jinja2
+requests


### PR DESCRIPTION
## Summary
- add a simple Jira client for creating issues, updating status and triggering pipelines
- expose preview endpoints under `/integrations/jira/*`
- document external integration in READMEs
- update requirements with requests dependency

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ab85df64832fbd1d52a53b1d1933