### PR TITLE
Add collaborative wiki space

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ contiene una colección lista para importar en Postman y probar todos los endpoi
 ## Autenticación
 
 Regístrate enviando un POST a `/users/` con `username` y `password`. El login se realiza en `/token` utilizando un formulario `application/x-www-form-urlencoded`.
+
+## Wiki colaborativa
+
+Este repositorio incluye un directorio [`wiki`](wiki/) que funciona como espacio de documentación colaborativa. Cualquier rol puede proponer mejoras o nuevas herramientas para el agente registrando sus ideas en [`wiki/ideas.md`](wiki/ideas.md).

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,12 @@
+# Wiki Colaborativa
+
+Este directorio actúa como un espacio de colaboración para todos los roles de la plataforma. Aquí se documentan ideas de mejora y propuestas de herramientas que podrían incorporarse al agente.
+
+## ¿Cómo participar?
+
+1. Crea o edita archivos Markdown dentro de la carpeta `wiki`.
+2. Indica tu rol y describe la idea de forma concisa.
+3. Registra propuestas de herramientas en `ideas.md` o crea archivos adicionales según sea necesario.
+4. Envía un Pull Request siguiendo las pautas generales del repositorio.
+
+Este wiki está abierto a aportes continuos y servirá como referencia para planificar futuras funcionalidades.

--- a/wiki/ideas.md
+++ b/wiki/ideas.md
@@ -1,0 +1,13 @@
+# Ideas de mejora y nuevas herramientas
+
+Este documento recopila sugerencias de todos los roles para ampliar las capacidades del agente.
+
+## Plantilla sugerida
+- **Rol**:
+- **Idea**:
+- **Motivación**:
+- **Herramientas o integraciones**:
+
+## Propuestas iniciales
+
+- *Ejemplo:* Incluir pruebas de accesibilidad automáticas con Lighthouse o herramientas similares.


### PR DESCRIPTION
## Summary
- add new `wiki` folder with README and ideas list
- link wiki in root README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ab8071a4832f8525c85bf177e52a