### PR TITLE
Add audit tables and event viewer

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,34 @@
+# Framework de Governance
+
+Este documento resume los pilares para establecer un control formal de la plataforma.
+
+## 1. Modelo de Madurez
+- **Nivel 1: Caótico**
+- **Nivel 2: Gestionado**
+- **Nivel 3: Definido**
+- **Nivel 4: Medido**
+- **Nivel 5: Optimizado**
+
+## 2. Auditoría y Compliance
+- Logs inmutables
+- Segregación de funciones
+- Aprobaciones multi-nivel
+- Reportes SOX/ISO
+
+## 3. Gestión de Riesgos
+- Risk assessment automático
+- Matriz de riesgos
+- Planes de mitigación
+- Escalamiento automático
+
+## 4. Políticas Empresariales
+- Retention de datos
+- Privacidad (GDPR)
+- Seguridad de información
+- Business continuity
+
+## 5. Métricas de Governance
+- Compliance score
+- Policy violations
+- Audit findings
+- Remediation time

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ contiene una colección lista para importar en Postman y probar todos los endpoi
 ## Autenticación
 
 Regístrate enviando un POST a `/users/` con `username` y `password`. El login se realiza en `/token` utilizando un formulario `application/x-www-form-urlencoded`.
+
+Para conocer el marco de governance consulta [GOVERNANCE.md](GOVERNANCE.md).
+
+Los administradores pueden revisar los eventos registrados consultando `/audit-events` y gestionar secretos en `/secrets/`.

--- a/backend/app/gateway.py
+++ b/backend/app/gateway.py
@@ -104,6 +104,21 @@ class AuditMiddleware(BaseHTTPMiddleware):
             project_id,
             payload,
         )
+        db = SessionLocal()
+        try:
+            event = models.AuditEvent(
+                user_id=user.id if user else None,
+                endpoint=request.url.path,
+                client_id=client_id,
+                project_id=project_id,
+                payload=json.dumps(payload) if payload is not None else None,
+            )
+            db.add(event)
+            db.commit()
+        except Exception:
+            db.rollback()
+        finally:
+            db.close()
         return response
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -431,3 +431,27 @@ class EnvironmentSchedule(Base):
     blackout = Column(Boolean, default=False)
 
     environment = relationship("Environment", back_populates="schedules")
+
+
+class AuditEvent(Base):
+    __tablename__ = "audit_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    timestamp = Column(DateTime, nullable=False, default=datetime.utcnow)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    endpoint = Column(String, nullable=False)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True)
+    payload = Column(String, nullable=True)
+
+    user = relationship("User")
+    client = relationship("Client")
+    project = relationship("Project")
+
+
+class Secret(Base):
+    __tablename__ = "secrets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    key = Column(String, unique=True, nullable=False)
+    value = Column(String, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -489,3 +489,32 @@ class Environment(EnvironmentBase):
 
     class Config:
         orm_mode = True
+
+
+class AuditEvent(BaseModel):
+    id: int
+    timestamp: datetime
+    user_id: Optional[int] = None
+    endpoint: str
+    client_id: Optional[int] = None
+    project_id: Optional[int] = None
+    payload: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+
+class SecretBase(BaseModel):
+    key: str
+    value: str
+
+
+class SecretCreate(SecretBase):
+    pass
+
+
+class Secret(SecretBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app import models
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def _login() -> str:
+    resp = client.post("/token", data={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_audit_log_created_and_viewable():
+    token = _login()
+    resp = client.get("/roles/", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    db = SessionLocal()
+    try:
+        events = db.query(models.AuditEvent).all()
+        assert len(events) >= 2
+    finally:
+        db.close()
+    resp = client.get(
+        "/audit-events",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) >= 2
+
+
+def test_secret_crud():
+    token = _login()
+    resp = client.post(
+        "/secrets/",
+        json={"key": "api", "value": "123"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    resp = client.get(
+        "/secrets/api",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["value"] == "123"


### PR DESCRIPTION
## Summary
- implement `AuditEvent` and `Secret` models
- record audit events from `AuditMiddleware`
- expose `/audit-events` and `/secrets` endpoints
- document admin features in README
- test audit logging and secret storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ab8ef3a8832faa9bd0ef99c8e2c2