### PR TITLE
Improve BI dashboard route

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,10 @@
     "bootstrap": "^5.3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.14.0",
+    "jspdf": "^2.5.1",
+    "chart.js": "^4.4.1",
+    "ng2-charts": "^4.0.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.0",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -38,7 +38,8 @@ export const routes: Routes = [
       { path: 'client-admin', loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent) },
       { path: 'actors', loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent) },
       { path: 'execution', loadComponent: () => import('./components/execution/execution.component').then(m => m.ExecutionComponent) },
-      { path: 'execution-monitor', loadComponent: () => import('./components/execution/execution-monitor-page.component').then(m => m.ExecutionMonitorPageComponent) }
+      { path: 'execution-monitor', loadComponent: () => import('./components/execution/execution-monitor-page.component').then(m => m.ExecutionMonitorPageComponent) },
+      { path: 'bi', loadComponent: () => import('./components/bi-dashboard/bi-dashboard.component').then(m => m.BiDashboardComponent) }
     ]
   },
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/components/bi-dashboard/bi-dashboard.component.ts
+++ b/frontend/src/app/components/bi-dashboard/bi-dashboard.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiService } from '../../services/api.service';
+import { NgChartsModule } from 'ng2-charts';
+import { ChartConfiguration } from 'chart.js';
+import jsPDF from 'jspdf';
+
+@Component({
+  selector: 'app-bi-dashboard',
+  standalone: true,
+  imports: [CommonModule, NgChartsModule],
+  template: `
+    <div class="main-panel">
+      <h1>BI Dashboard</h1>
+      <button class="btn btn-primary mb-3" (click)="exportPdf()">Exportar PDF</button>
+      <div *ngIf="metrics?.manager">
+        <h2>Scripts por Cliente</h2>
+        <canvas baseChart [data]="clientChartData" [type]="'pie'"></canvas>
+
+        <h2 class="mt-4">Scripts por Analista</h2>
+        <canvas baseChart [data]="analystChartData" [type]="'pie'"></canvas>
+
+        <div class="mt-4">
+          <p><strong>Mejor analista:</strong> {{ metrics.manager.best_analyst || 'N/A' }}</p>
+          <p><strong>Ejecuciones fallidas:</strong> {{ metrics.manager.failed_executions || 0 }}</p>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .main-panel { padding: 1rem; }
+    canvas { max-width: 400px; display: block; margin: 1rem auto; }
+  `]
+})
+export class BiDashboardComponent implements OnInit {
+  metrics: any;
+  clientChartData: ChartConfiguration<'pie'>['data'] = { labels: [], datasets: [{ data: [] }] };
+  analystChartData: ChartConfiguration<'pie'>['data'] = { labels: [], datasets: [{ data: [] }] };
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getDashboardMetrics().subscribe(m => {
+      this.metrics = m;
+      this.prepareCharts();
+    });
+  }
+
+  prepareCharts() {
+    if (!this.metrics?.manager) return;
+    const clients = this.metrics.manager.clients || [];
+    this.clientChartData.labels = clients.map((c: any) => c.name);
+    this.clientChartData.datasets[0].data = clients.map((c: any) => c.scripts);
+
+    const analysts = this.metrics.manager.analysts || [];
+    this.analystChartData.labels = analysts.map((a: any) => a.name);
+    this.analystChartData.datasets[0].data = analysts.map((a: any) => a.scripts);
+  }
+
+  exportPdf() {
+    const doc = new jsPDF();
+    doc.text('BI Dashboard Metrics', 10, 10);
+    doc.text(JSON.stringify(this.metrics, null, 2), 10, 20);
+    doc.save('bi-dashboard.pdf');
+  }
+}


### PR DESCRIPTION
## Summary
- extend manager metrics with analyst and execution info
- show professional pie charts in BI dashboard
- add chart.js and ng2-charts dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `npm test --silent -- --browsers=ChromeHeadless --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab6266c8832f9957222cd05c4538