### PR TITLE
Implement auth guard and workspace UI fixes

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,12 +11,13 @@ export const routes: Routes = [
   },
   {
     path: 'workspace',
-    loadComponent: () => import('./components/workspace-selector/workspace-selector.component').then(m => m.WorkspaceSelectorComponent)
+    loadComponent: () => import('./components/workspace-selector/workspace-selector.component').then(m => m.WorkspaceSelectorComponent),
+    canActivate: [() => import('./auth.guard').then(m => m.authGuard)]
   },
   {
     path: '',
     loadComponent: () => import('./components/main-layout/main-layout.component').then(m => m.MainLayoutComponent),
-    canActivate: [() => import('./workspace.guard').then(m => m.canActivateWorkspace)],
+    canActivate: [() => import('./auth.guard').then(m => m.authGuard), () => import('./workspace.guard').then(m => m.canActivateWorkspace)],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', loadComponent: () => import('./components/dashboard/dashboard.component').then(m => m.DashboardComponent) },

--- a/frontend/src/app/auth.guard.ts
+++ b/frontend/src/app/auth.guard.ts
@@ -1,0 +1,9 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+
+export const authGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+  return api.isAuthenticated() ? true : router.createUrlTree(['/login']);
+};


### PR DESCRIPTION
## Summary
- add `authGuard` and enforce login for workspace and main layout
- show logout + dashboard buttons in workspace selector
- fetch all clients for service manager users

## Testing
- `pytest -q tests` *(fails: assert 429 == 200)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6855cd91f6f8832fb501835b99ea6a74