### PR TITLE
Implement auth guard and workspace UI fixes

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,12 +11,13 @@ export const routes: Routes = [
   },
   {
     path: 'workspace',
-    loadComponent: () => import('./components/workspace-selector/workspace-selector.component').then(m => m.WorkspaceSelectorComponent)
+    loadComponent: () => import('./components/workspace-selector/workspace-selector.component').then(m => m.WorkspaceSelectorComponent),
+    canActivate: [() => import('./auth.guard').then(m => m.authGuard)]
   },
   {
     path: '',
     loadComponent: () => import('./components/main-layout/main-layout.component').then(m => m.MainLayoutComponent),
-    canActivate: [() => import('./workspace.guard').then(m => m.canActivateWorkspace)],
+    canActivate: [() => import('./auth.guard').then(m => m.authGuard), () => import('./workspace.guard').then(m => m.canActivateWorkspace)],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', loadComponent: () => import('./components/dashboard/dashboard.component').then(m => m.DashboardComponent) },

--- a/frontend/src/app/auth.guard.ts
+++ b/frontend/src/app/auth.guard.ts
@@ -1,0 +1,9 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+
+export const authGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+  return api.isAuthenticated() ? true : router.createUrlTree(['/login']);
+};

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -21,7 +21,7 @@ interface MenuItem {
     <div class="layout-container" [class.sidebar-open]="sidebarOpen">
       <header class="header">
         <button class="hamburger" (click)="toggleSidebar()">☰</button>
-        <div class="logo">Analista de Pruebas</div>
+        <div class="logo">{{ headerTitle }}</div>
         <div class="workspace-info" *ngIf="clientName && projectName">
           <span class="chip">{{ clientName }}</span>
           <span class="chip">{{ projectName }}</span>
@@ -91,6 +91,7 @@ export class MainLayoutComponent implements OnInit {
   userMenuOpen = false;
   clientName = '';
   projectName = '';
+  headerTitle = 'GPTTester';
 
   constructor(
     private api: ApiService,
@@ -113,6 +114,7 @@ export class MainLayoutComponent implements OnInit {
     if (this.api.isAuthenticated()) {
       this.api.getCurrentUser().subscribe(u => {
         this.currentUser = u;
+        this.headerTitle = u.role?.name || this.headerTitle;
         this.setMenuByRole(u.role?.name || '');
       });
     }
@@ -154,7 +156,10 @@ export class MainLayoutComponent implements OnInit {
   }
 
   setMenuByRole(role: string) {
-    const gs = [{ label: 'Gestión', route: '/service-manager', icon: '📊' }];
+    const gs = [
+      { label: 'Gestión', route: '/service-manager', icon: '📊' },
+      { label: 'Indicadores', route: '/bi', icon: '📈' }
+    ];
     const analyst = [
       { label: 'Crear scripts', route: '/test-cases', icon: '📝' },
       { label: 'Parametrizar', route: '/actions', icon: '⚙️' },


### PR DESCRIPTION
## Summary
- add `authGuard` and enforce login for workspace and main layout
- show logout + dashboard buttons in workspace selector
- fetch all clients for service manager users
- dynamic header title by role and new indicators menu option

## Testing
- `pytest -q tests` *(fails: ModuleNotFoundError: fastapi)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_6855cd91f6f8832fb501835b99ea6a74