### PR TITLE
Add initial data seeding and basic API permissions

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -8,7 +8,10 @@ from . import models, deps
 def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
     router = APIRouter(prefix=f"/{prefix}", tags=[prefix])
 
-    @router.post("/", response_model=schema)
+    def perm(method: str):
+        return Depends(deps.require_api_permission(f"/{prefix}", method))
+
+    @router.post("/", response_model=schema, dependencies=[perm("POST")])
     def create(item: schema, db: Session = Depends(deps.get_db)):
         data = item.dict()
         if model is models.User:
@@ -19,18 +22,18 @@ def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
         db.refresh(db_obj)
         return db_obj
 
-    @router.get("/", response_model=List[schema])
+    @router.get("/", response_model=List[schema], dependencies=[perm("GET")])
     def read_all(db: Session = Depends(deps.get_db)):
         return db.query(model).all()
 
-    @router.get("/{item_id}", response_model=schema)
+    @router.get("/{item_id}", response_model=schema, dependencies=[perm("GET")])
     def read_one(item_id: int, db: Session = Depends(deps.get_db)):
         db_obj = db.query(model).filter(model.id == item_id).first()
         if not db_obj:
             raise HTTPException(status_code=404, detail="Not found")
         return db_obj
 
-    @router.put("/{item_id}", response_model=schema)
+    @router.put("/{item_id}", response_model=schema, dependencies=[perm("PUT")])
     def update(item_id: int, item: schema, db: Session = Depends(deps.get_db)):
         db_obj = db.query(model).filter(model.id == item_id).first()
         if not db_obj:
@@ -44,7 +47,7 @@ def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
         db.refresh(db_obj)
         return db_obj
 
-    @router.delete("/{item_id}")
+    @router.delete("/{item_id}", dependencies=[perm("DELETE")])
     def delete(item_id: int, db: Session = Depends(deps.get_db)):
         db_obj = db.query(model).filter(model.id == item_id).first()
         if not db_obj:


### PR DESCRIPTION
## Summary
- seed default records for roles and lookups during app startup
- enforce API permissions on CRUD routes

## Testing
- `pytest -q` *(fails: RuntimeError: attribute errors and 404s)*

------
https://chatgpt.com/codex/tasks/task_e_686470dd727c832f8b3b1704acc8a4d3