### PR TITLE
Simplified angular frontend

### DIFF
--- a/frontend/README2.md
+++ b/frontend/README2.md
@@ -2,6 +2,9 @@
 
 Este es el frontend desarrollado en Angular con TypeScript y Bootstrap para el sistema de automatización de pruebas.
 
+### Estado actual
+Por ahora la aplicación solo incluye las pantallas de inicio de sesión, registro y la gestión básica de clientes y actores.
+
 ## Características
 
 - **Framework**: Angular 17 con TypeScript

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,40 +10,19 @@ export const routes: Routes = [
     loadComponent: () => import('./components/register/register.component').then(m => m.RegisterComponent)
   },
   {
-    path: 'workspace',
-    loadComponent: () => import('./components/workspace-selector/workspace-selector.component').then(m => m.WorkspaceSelectorComponent),
-    canActivate: [() => import('./auth.guard').then(m => m.authGuard)]
-  },
-  {
     path: '',
     loadComponent: () => import('./components/main-layout/main-layout.component').then(m => m.MainLayoutComponent),
-    canActivate: [() => import('./auth.guard').then(m => m.authGuard), () => import('./workspace.guard').then(m => m.canActivateWorkspace)],
+    canActivate: [() => import('./auth.guard').then(m => m.authGuard)],
     children: [
-      { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
-      { path: 'dashboard', loadComponent: () => import('./components/dashboard/dashboard.component').then(m => m.DashboardComponent) },
-      { path: 'users', loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent), canActivate: [() => import('./admin.guard').then(m => m.adminGuard)] },
-      { path: 'roles', loadComponent: () => import('./components/roles/roles.component').then(m => m.RolesComponent) },
-      { path: 'flow-builder', loadComponent: () => import('./components/flow-builder/flow-builder.component').then(m => m.FlowBuilderComponent) },
-      { path: 'test-plans', loadComponent: () => import('./components/test-plans/test-plans.component').then(m => m.TestPlansComponent) },
-      { path: 'test-cases', loadComponent: () => import('./components/test-cases/test-cases.component').then(m => m.TestCasesComponent) },
-      { path: 'scripts', loadComponent: () => import('./components/scripts/scripts.component').then(m => m.ScriptsComponent) },
-      { path: 'bdd-builder', loadComponent: () => import('./components/scripts/bdd-script-wizard.component').then(m => m.BddScriptWizardComponent) },
-      { path: 'parameterization/:testId', loadComponent: () => import('./components/parameterization/parameterization.component').then(m => m.ParameterizationComponent) },
-      { path: 'visual-param', loadComponent: () => import('./components/visual-parameterization/visual-parameterization.component').then(m => m.VisualParameterizationComponent) },
-      { path: 'pages', loadComponent: () => import('./components/pages/pages.component').then(m => m.PagesComponent) },
-      { path: 'elements', loadComponent: () => import('./components/elements/elements.component').then(m => m.ElementsComponent) },
-
-      { path: 'actions', loadComponent: () => import('./components/actions/actions.component').then(m => m.ActionsComponent) },
-      { path: 'agents', loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent) },
-      { path: 'marketplace', loadComponent: () => import('./components/marketplace/marketplace.component').then(m => m.MarketplaceComponent) },
-      { path: 'projects', loadComponent: () => import('./components/client-admin/client-projects.component').then(m => m.ClientProjectsComponent) },
-      { path: 'service-manager', loadComponent: () => import('./components/service-manager/service-manager.component').then(m => m.ServiceManagerComponent) },
-      { path: 'client-admin', loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent) },
-      { path: 'actors', loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent) },
-      { path: 'performance', loadComponent: () => import('./components/performance/performance.component').then(m => m.PerformanceComponent) },
-       { path: 'execution', loadComponent: () => import('./components/execution/execution.component').then(m => m.ExecutionComponent) },
-      { path: 'execution-monitor', loadComponent: () => import('./components/execution/execution-monitor-page.component').then(m => m.ExecutionMonitorPageComponent) },
-      { path: 'bi', loadComponent: () => import('./components/bi-dashboard/bi-dashboard.component').then(m => m.BiDashboardComponent) }
+      { path: '', redirectTo: 'clients', pathMatch: 'full' },
+      {
+        path: 'clients',
+        loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent)
+      },
+      {
+        path: 'actors',
+        loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent)
+      }
     ]
   },
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -176,25 +176,8 @@ export class LoginComponent {
 
     this.apiService.login(this.credentials).subscribe({
       next: () => {
-        this.apiService.getCurrentUser().subscribe({
-          next: (user) => {
-            const role = user.role?.name || '';
-            this.isLoading = false;
-            if (role === 'Administrador') {
-              this.router.navigate(['/users']);
-            } else if (role === 'Arquitecto de Automatización' || role === 'Automation Engineer') {
-              this.router.navigate(['/actions']);
-            } else if (role === 'Gerente de servicios') {
-              this.router.navigate(['/client-admin']);
-            } else {
-              this.router.navigate(['/dashboard']);
-            }
-          },
-          error: () => {
-            this.isLoading = false;
-            this.router.navigate(['/dashboard']);
-          }
-        });
+        this.isLoading = false;
+        this.router.navigate(['/clients']);
       },
       error: (error) => {
         this.isLoading = false;

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -2,9 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { ApiService } from '../../services/api.service';
-import { WorkspaceService } from '../../services/workspace.service';
-import { ClientService } from '../../services/client.service';
-import { ProjectService } from '../../services/project.service';
 import { User } from '../../models';
 
 interface MenuItem {
@@ -22,11 +19,6 @@ interface MenuItem {
       <header class="header">
         <button class="hamburger" (click)="toggleSidebar()">☰</button>
         <div class="logo">{{ headerTitle }}</div>
-        <div class="workspace-info" *ngIf="clientName && projectName">
-          <span class="chip">{{ clientName }}</span>
-          <span class="chip">{{ projectName }}</span>
-          <button class="btn-link" (click)="changeWorkspace()">Cambiar workspace</button>
-        </div>
         <div class="user" *ngIf="currentUser">
           <span class="user-name" (click)="userMenuOpen = !userMenuOpen">{{ currentUser.username }}</span>
           <ul class="user-menu" *ngIf="userMenuOpen">
@@ -61,7 +53,6 @@ interface MenuItem {
     .header { display: flex; align-items: center; justify-content: space-between; padding: 0.5rem 1rem; background: var(--panel-bg); border-bottom: 1px solid var(--border-color); position: relative; }
     .hamburger { background: none; border: none; font-size: 1.5rem; margin-right: 1rem; display: none; }
     .logo { font-weight: 600; }
-    .workspace-info { display: flex; align-items: center; gap: 0.5rem; }
     .chip { background: var(--bg-general-alt); border-radius: 12px; padding: 0.25rem 0.75rem; font-size: 0.75rem; }
     .user { position: relative; }
     .user-name { cursor: pointer; }
@@ -86,18 +77,16 @@ interface MenuItem {
 })
 export class MainLayoutComponent implements OnInit {
   currentUser: User | null = null;
-  menu: MenuItem[] = [];
+  menu: MenuItem[] = [
+    { label: 'Clientes', route: '/clients', icon: '🏢' },
+    { label: 'Actores', route: '/actors', icon: '🎭' }
+  ];
   sidebarOpen = false;
   userMenuOpen = false;
-  clientName = '';
-  projectName = '';
   headerTitle = 'GPTTester';
 
   constructor(
     private api: ApiService,
-    private workspace: WorkspaceService,
-    private clientService: ClientService,
-    private projectService: ProjectService,
     private router: Router
   ) {}
 
@@ -106,31 +95,9 @@ export class MainLayoutComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (!this.workspace.hasWorkspace()) {
-      this.router.navigate(['/workspace']);
-      return;
-    }
-
     if (this.api.isAuthenticated()) {
       this.api.getCurrentUser().subscribe(u => {
         this.currentUser = u;
-        this.headerTitle = u.role?.name || this.headerTitle;
-        this.setMenuByRole(u.role?.name || '');
-      });
-    }
-
-    const cid = this.workspace.clientId;
-    const pid = this.workspace.projectId;
-    if (cid) {
-      this.clientService.getClients().subscribe(cs => {
-        const found = cs.find(c => c.id === cid);
-        if (found) this.clientName = found.name;
-      });
-    }
-    if (pid) {
-      this.projectService.getProjects().subscribe(ps => {
-        const found = ps.find(p => p.id === pid);
-        if (found) this.projectName = found.name;
       });
     }
   }
@@ -148,38 +115,5 @@ export class MainLayoutComponent implements OnInit {
   logout() {
     this.api.logout();
     this.router.navigate(['/login']);
-  }
-
-  changeWorkspace() {
-    this.workspace.clearWorkspace();
-    this.router.navigate(['/workspace']);
-  }
-
-  setMenuByRole(role: string) {
-    const gs = [
-      { label: 'Gestión', route: '/service-manager', icon: '📊' },
-      { label: 'Indicadores', route: '/bi', icon: '📈' }
-    ];
-    const analyst = [
-      { label: 'Crear scripts', route: '/test-cases', icon: '📝' },
-      { label: 'Parametrizar', route: '/actions', icon: '⚙️' },
-      { label: 'Ejecutar pruebas', route: '/execution', icon: '▶️' },
-      { label: 'Performance', route: '/performance', icon: '🚀' }
-    ];
-    const adminExtra = [{ label: 'Gestión de usuarios', route: '/users', icon: '👥' }];
-    const architect = [
-      { label: 'Métricas', route: '/dashboard', icon: '📈' },
-      { label: 'Configuración avanzada', route: '/roles', icon: '🛠️' }
-    ];
-
-    if (role === 'Administrador') {
-      this.menu = [...gs, ...analyst, ...architect, ...adminExtra];
-    } else if (role === 'Gerente de servicios') {
-      this.menu = gs;
-    } else if (role === 'Arquitecto de Automatización') {
-      this.menu = architect;
-    } else {
-      this.menu = analyst;
-    }
   }
 }

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -151,25 +151,8 @@ export class RegisterComponent {
         const creds: LoginRequest = { username: this.form.username, password: this.form.password };
         this.api.login(creds).subscribe({
           next: () => {
-            this.api.getCurrentUser().subscribe({
-              next: (user) => {
-                const role = user.role?.name || '';
-                this.isLoading = false;
-                if (role === 'Administrador') {
-                  this.router.navigate(['/users']);
-                } else if (role === 'Arquitecto de Automatización' || role === 'Automation Engineer') {
-                  this.router.navigate(['/actions']);
-                } else if (role === 'Gerente de servicios') {
-                  this.router.navigate(['/client-admin']);
-                } else {
-                  this.router.navigate(['/dashboard']);
-                }
-              },
-              error: () => {
-                this.isLoading = false;
-                this.router.navigate(['/dashboard']);
-              }
-            });
+            this.isLoading = false;
+            this.router.navigate(['/clients']);
           },
           error: () => {
             this.isLoading = false;


### PR DESCRIPTION
## Summary
- strip routes to only login/registration/clients/actors
- simplify main layout without workspaces
- after login or register go to client list
- document reduced functionality in README

## Testing
- `npm test` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686472e08bb0832f8edfdfda1660a7d3