### PR TITLE
Improve DB docs with clearer diagrams

### DIFF
--- a/DB/auth.md
+++ b/DB/auth.md
@@ -1,0 +1,19 @@
+# Usuarios, Roles y Permisos
+
+Las tablas principales para seguridad son:
+
+- `roles`: define cada rol disponible en la plataforma.
+- `users`: almacena credenciales y referencia al rol asignado.
+- `page_permissions`: controla a qué páginas del frontend puede acceder cada rol.
+- `api_permissions`: restringe las rutas y métodos de la API por rol.
+
+Con esta estructura el backend valida cada petición verificando el rol del usuario autenticado y consultando sus permisos. Al definir permisos por página y por endpoint se logra un control fino que evita accesos no autorizados en todos los niveles de la aplicación.
+
+```mermaid
+flowchart LR
+    Users((Usuarios)) --> Roles((Roles))
+    Roles --> PagePerms["Permisos de páginas"]
+    Roles --> ApiPerms["Permisos de API"]
+```
+
+En el diagrama puede verse de forma simple cómo los roles conectan a los usuarios con los permisos de cada página o API.

--- a/DB/clients_and_projects.md
+++ b/DB/clients_and_projects.md
@@ -1,0 +1,21 @@
+# Clientes y Proyectos
+
+Este dominio gestiona la relación con los clientes y los activos digitales que se prueban.
+
+- `clients` agrupa la información básica de cada cliente.
+- `business_agreements` y `digital_assets` documentan los acuerdos y productos contratados.
+- `user_interfaces`, `element_types` y `elements` describen la estructura de las interfaces de usuario.
+- `projects` y `project_employees` permiten asignar usuarios a proyectos con distintas dedicaciones.
+- `actors` y `habilities` registran los perfiles involucrados dentro del cliente.
+
+Cada proyecto se vincula a un cliente y puede tener múltiples analistas asignados, garantizando trazabilidad entre los acuerdos comerciales y los flujos de pruebas ejecutados.
+
+```mermaid
+flowchart LR
+    Clients((Clientes)) --> Agreements["Acuerdos"]
+    Clients --> Assets["Activos digitales"]
+    Assets --> Projects((Proyectos))
+    Projects --> Employees["Empleados asignados"]
+```
+
+Este esquema simplificado ilustra cómo la información de cada cliente se enlaza con sus acuerdos, activos y proyectos.

--- a/DB/general.md
+++ b/DB/general.md
@@ -1,0 +1,19 @@
+# Información General de la Base de Datos
+
+Este proyecto usa SQLAlchemy y PostgreSQL. Todas las entidades se definen en `backend/app/models.py` y se inicializan automáticamente al levantar la aplicación. Las tablas se agrupan en cuatro grandes dominios:
+
+1. **Autenticación y seguridad**: gestiona usuarios, roles y permisos.
+2. **Clientes y proyectos**: organiza clientes, acuerdos y activos digitales.
+3. **Interacciones y validaciones**: registra flujos de trabajo y sus aprobaciones.
+4. **Escenarios y datos de prueba**: describe casos de prueba y datos asociados.
+
+En total existen más de treinta tablas relacionadas entre sí mediante claves foráneas. El esquema facilita la trazabilidad completa desde las funcionalidades hasta los datos de prueba ejecutados.
+
+```mermaid
+flowchart LR
+    Seguridad["Autenticación\n y seguridad"] --> Clientes["Clientes y proyectos"]
+    Clientes --> Interacciones["Interacciones y validaciones"]
+    Interacciones --> Escenarios["Escenarios y datos de prueba"]
+```
+
+El diagrama anterior resume cómo cada dominio se relaciona de forma secuencial. Así resulta más fácil comprender la estructura global sin necesidad de profundizar en detalles técnicos.

--- a/DB/interactions.md
+++ b/DB/interactions.md
@@ -1,0 +1,21 @@
+# Interacciones y Validaciones
+
+Estas tablas modelan los pasos de prueba, sus parámetros y el flujo de aprobaciones.
+
+- `interactions` y `interaction_parameters` definen acciones automatizadas con sus argumentos.
+- `interaction_approval_states` y `interaction_approvals` permiten registrar revisiones por pares.
+- `validations`, `validation_parameters` y `validation_approvals` almacenan las comprobaciones posteriores.
+- `tasks` y `task_have_interactions` conectan interacciones con tareas de alto nivel.
+
+El registro de aprobaciones y revisiones facilita el control de calidad antes de ejecutar cualquier acción en los entornos de prueba.
+
+```mermaid
+flowchart LR
+    Interaction --> Params["Parámetros"]
+    Interaction --> Approvals["Aprobaciones"]
+    Interaction --> TaskLink["Tareas"]
+    Validation --> VParams["Parámetros de validación"]
+    Validation --> VApprovals["Aprobaciones de validación"]
+```
+
+La gráfica muestra el ciclo básico de una interacción y sus validaciones asociadas.

--- a/DB/scenarios.md
+++ b/DB/scenarios.md
@@ -1,0 +1,20 @@
+# Escenarios y Datos de Prueba
+
+Este grupo describe los casos de prueba, las preguntas que los componen y los datos necesarios para ejecutarlos.
+
+- `questions` y `question_has_validations` agrupan validaciones por pregunta.
+- `scenarios` relaciona las preguntas con `scenario_info` y `feature_steps` para representar casos BDD.
+- `scenario_data` almacena instancias de ejecución vinculadas a `raw_data` y `field_types`.
+- `features`, `scenario_has_features` y `feature_steps` permiten organizar las funcionalidades en scripts reutilizables.
+
+Con estas tablas se consigue una completa trazabilidad desde cada requisito hasta los datos generados para las pruebas automatizadas.
+
+```mermaid
+flowchart LR
+    Question --> QValidations["Validaciones"]
+    Question --> Scenario
+    Scenario --> ScenarioData["Datos de ejecución"]
+    Scenario --> Features["Funcionalidades"]
+```
+
+Este diagrama resume de forma visual cómo un escenario agrupa preguntas y genera datos de prueba asociados.

--- a/readme2.md
+++ b/readme2.md
@@ -1,0 +1,47 @@
+# Diagrama General de la Base de Datos
+
+A continuación se muestra primero un esquema simplificado para facilitar la comprensión de los distintos dominios:
+
+```mermaid
+flowchart TB
+    Usuarios["Usuarios y seguridad"] --> Clientes["Clientes y proyectos"]
+    Clientes --> Interacciones["Interacciones y validaciones"]
+    Interacciones --> Escenarios["Escenarios y datos de prueba"]
+```
+
+Para quienes requieran más detalle también se incluye un diagrama UML con todas las tablas relevantes:
+
+```mermaid
+classDiagram
+    Role <|-- User
+    Role <|-- PagePermission
+    Role <|-- ApiPermission
+    Client <|-- BusinessAgreement
+    Client <|-- DigitalAsset
+    DigitalAsset <|-- UserInterface
+    UserInterface <|-- Element
+    Element --> ElementType
+    DigitalAsset <|-- Project
+    Project <|-- ProjectEmployee
+    User <|-- ProjectEmployee
+    Client <|-- Actor
+    Actor --> Hability
+    Interaction <|-- InteractionParameter
+    Interaction <|-- TaskHaveInteraction
+    InteractionApprovalState <|-- InteractionApproval
+    Interaction <|-- InteractionApproval
+    User <|-- InteractionApproval
+    Validation <|-- ValidationParameter
+    Validation <|-- ValidationApproval
+    Question <|-- QuestionHasValidation
+    Scenario <|-- ScenarioData
+    Scenario <|-- ScenarioHasFeature
+    Feature <|-- ScenarioHasFeature
+    FeatureStep <|-- ScenarioInfo
+    Question <|-- FeatureStep
+    Task <|-- FeatureStep
+    ScenarioData <|-- RawData
+    RawData <|-- FieldType
+```
+
+Este diagrama resume las relaciones principales entre las entidades. Las flechas indican dependencias mediante claves foráneas. De esta forma puede verse cómo los usuarios se vinculan a roles y permisos, los clientes a sus proyectos y activos digitales, y los escenarios a sus datos de prueba.


### PR DESCRIPTION
## Summary
- add simplified flowchart to the main DB diagram in `readme2.md`
- include quick diagrams in each DB domain document for easy reading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68647624ab94832fb2be5fdcc1ebd3c6