### PR TITLE
Fix CORS for login

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
 from .database import engine, SessionLocal
@@ -114,6 +115,15 @@ models.Base.metadata.create_all(bind=engine)
 seed_database()
 
 app = FastAPI(title="Test Automation API")
+
+# Enable CORS for frontend requests
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.post("/token")


### PR DESCRIPTION
## Summary
- enable FastAPI CORSMiddleware

## Testing
- `pytest -q` *(fails: AuditEvent missing etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864793c2f68832f88bc06dbc3b3bf90