### PR TITLE
Add logout button with username display

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -127,6 +127,12 @@ def login(
     return {"access_token": token, "token_type": "bearer"}
 
 
+@app.post("/logout")
+def logout(token: str = Depends(deps.oauth2_scheme)):
+    deps.revoke_token(token)
+    return {"ok": True}
+
+
 # CRUD routers for main entities
 def register_cruds():
     mappings = [

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -19,11 +19,9 @@ interface MenuItem {
       <header class="header">
         <button class="hamburger" (click)="toggleSidebar()">☰</button>
         <div class="logo">{{ headerTitle }}</div>
-        <div class="user" *ngIf="currentUser">
-          <span class="user-name" (click)="userMenuOpen = !userMenuOpen">{{ currentUser.username }}</span>
-          <ul class="user-menu" *ngIf="userMenuOpen">
-            <li (click)="logout()">Cerrar sesión</li>
-          </ul>
+        <div class="user-info" *ngIf="currentUser">
+          <span class="user-name">{{ currentUser.username }}</span>
+          <button class="btn-logout" (click)="logout()">Salir</button>
         </div>
       </header>
 
@@ -54,11 +52,8 @@ interface MenuItem {
     .hamburger { background: none; border: none; font-size: 1.5rem; margin-right: 1rem; display: none; }
     .logo { font-weight: 600; }
     .chip { background: var(--bg-general-alt); border-radius: 12px; padding: 0.25rem 0.75rem; font-size: 0.75rem; }
-    .user { position: relative; }
-    .user-name { cursor: pointer; }
-    .user-menu { list-style: none; position: absolute; right: 0; top: 100%; background: var(--panel-bg); border: 1px solid var(--border-color); border-radius: 4px; padding: 0.5rem 0; margin: 0; }
-    .user-menu li { padding: 0.25rem 1rem; cursor: pointer; }
-    .user-menu li:hover { background: var(--bg-general-alt); }
+    .user-info { display: flex; align-items: center; gap: 0.5rem; }
+    .btn-logout { background: var(--btn-primary); color: var(--btn-primary-text); border: none; padding: 0.25rem 0.75rem; border-radius: 4px; cursor: pointer; }
     .layout-grid { display: flex; flex: 1; }
     .sidebar { width: 200px; background: var(--panel-bg); border-right: 1px solid var(--border-color); }
     .sidebar ul { list-style: none; margin: 0; padding: 0; }
@@ -82,7 +77,6 @@ export class MainLayoutComponent implements OnInit {
     { label: 'Actores', route: '/actors', icon: '🎭' }
   ];
   sidebarOpen = false;
-  userMenuOpen = false;
   headerTitle = 'GPTTester';
 
   constructor(

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -47,8 +47,17 @@ export class ApiService {
   }
 
   logout(): void {
-    localStorage.removeItem('token');
-    this.tokenSubject.next(null);
+    this.http.post(`${this.baseUrl}/logout`, {}, { headers: this.getHeaders() })
+      .subscribe({
+        complete: () => {
+          localStorage.removeItem('token');
+          this.tokenSubject.next(null);
+        },
+        error: () => {
+          localStorage.removeItem('token');
+          this.tokenSubject.next(null);
+        }
+      });
   }
 
   getCurrentUser(): Observable<User> {

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def _login() -> str:
+    resp = client.post("/token", data={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_logout_revokes_token():
+    token = _login()
+    resp = client.post("/logout", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+    resp = client.get("/roles/", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- display logged-in user name in header
- add logout button to easily end the session

## Testing
- `pytest -q` *(fails: Module 'backend.app.models' has no attribute 'AuditEvent', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686479a002d4832fbba47956e26de0ab