### PR TITLE
Update sidebar to support full hierarchy

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -20,8 +20,32 @@ export const routes: Routes = [
         loadComponent: () => import('./components/client-admin/client-admin.component').then(m => m.ClientAdminComponent)
       },
       {
-        path: 'actors',
+        path: 'clients/:clientId/actors',
         loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent)
+      },
+      {
+        path: 'clients/:clientId/projects',
+        loadComponent: () => import('./components/projects/projects.component').then(m => m.ProjectsComponent)
+      },
+      {
+        path: 'projects/:projectId/scenarios',
+        loadComponent: () => import('./components/scenarios/scenarios.component').then(m => m.ScenariosComponent)
+      },
+      {
+        path: 'projects/:projectId/scenarios/:scenarioId/tasks',
+        loadComponent: () => import('./components/tasks/tasks.component').then(m => m.TasksComponent)
+      },
+      {
+        path: 'projects/:projectId/scenarios/:scenarioId/data',
+        loadComponent: () => import('./components/scenario-data/scenario-data.component').then(m => m.ScenarioDataComponent)
+      },
+      {
+        path: 'projects/:projectId/features',
+        loadComponent: () => import('./components/features/features.component').then(m => m.FeaturesComponent)
+      },
+      {
+        path: 'interactions',
+        loadComponent: () => import('./components/interactions/interactions.component').then(m => m.InteractionsComponent)
       }
     ]
   },

--- a/frontend/src/app/components/actors/actor-form.component.ts
+++ b/frontend/src/app/components/actors/actor-form.component.ts
@@ -20,7 +20,12 @@ import { ApiService } from '../../services/api.service';
           </div>
           <div class="mb-3">
             <label class="form-label">Cliente</label>
-            <select class="form-control" [(ngModel)]="form.client_id" name="client_id" required>
+            <select
+              class="form-control"
+              [(ngModel)]="form.client_id"
+              name="client_id"
+              [disabled]="clientId !== null"
+              required>
               <option *ngFor="let c of clients" [ngValue]="c.id">{{ c.name }}</option>
             </select>
           </div>
@@ -33,6 +38,7 @@ import { ApiService } from '../../services/api.service';
 })
 export class ActorFormComponent implements OnInit {
   @Input() actor: Actor | null = null;
+  @Input() clientId: number | null = null;
   @Output() saved = new EventEmitter<void>();
   @Output() cancel = new EventEmitter<void>();
 
@@ -48,6 +54,8 @@ export class ActorFormComponent implements OnInit {
       this.loadClients();
       if (this.actor) {
         this.form = { name: this.actor.name, client_id: this.actor.client_id };
+      } else if (this.clientId) {
+        this.form.client_id = this.clientId;
       }
     });
   }

--- a/frontend/src/app/components/actors/actors.component.ts
+++ b/frontend/src/app/components/actors/actors.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { Actor, Client, User } from '../../models';
 import { ActorService } from '../../services/actor.service';
 import { ApiService } from '../../services/api.service';
@@ -13,7 +14,7 @@ import { ActorFormComponent } from './actor-form.component';
   template: `
     <div class="main-panel">
       <h1>Gestión de Actores</h1>
-      <div class="mb-3">
+      <div class="mb-3" *ngIf="!hasRouteClient">
         <label>Cliente</label>
         <select class="form-select" [(ngModel)]="selectedClient" (change)="load()">
           <option [ngValue]="null">Todos</option>
@@ -38,7 +39,12 @@ import { ActorFormComponent } from './actor-form.component';
       </table>
       <div *ngIf="actors.length === 0">No hay actores.</div>
 
-      <app-actor-form *ngIf="showForm" [actor]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-actor-form>
+      <app-actor-form
+        *ngIf="showForm"
+        [actor]="editing"
+        [clientId]="selectedClient"
+        (saved)="onSaved()"
+        (cancel)="showForm=false"></app-actor-form>
     </div>
   `
 })
@@ -47,12 +53,22 @@ export class ActorsComponent implements OnInit {
   clients: Client[] = [];
   currentUser: User | null = null;
   selectedClient: number | null = null;
+  hasRouteClient = false;
   showForm = false;
   editing: Actor | null = null;
 
-  constructor(private service: ActorService, private api: ApiService) {}
+  constructor(
+    private service: ActorService,
+    private api: ApiService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
+    const cid = this.route.snapshot.paramMap.get('clientId');
+    if (cid) {
+      this.selectedClient = Number(cid);
+      this.hasRouteClient = true;
+    }
     this.api.getCurrentUser().subscribe(user => {
       this.currentUser = user;
       this.loadClients();

--- a/frontend/src/app/components/features/features.component.ts
+++ b/frontend/src/app/components/features/features.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-features',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Features</h1>
+      <p>Proyecto ID: {{ projectId }}</p>
+    </div>
+  `
+})
+export class FeaturesComponent implements OnInit {
+  projectId!: number;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.projectId = Number(this.route.snapshot.paramMap.get('projectId'));
+  }
+}

--- a/frontend/src/app/components/interactions/interactions.component.ts
+++ b/frontend/src/app/components/interactions/interactions.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-interactions',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Interacciones por Defecto</h1>
+    </div>
+  `
+})
+export class InteractionsComponent {}

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -2,12 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { ApiService } from '../../services/api.service';
-import { User } from '../../models';
+import { User, Client, Project } from '../../models';
 
 interface MenuItem {
   label: string;
-  route: string;
+  route?: string;
   icon: string;
+  children?: { label: string; route: string; icon: string }[];
 }
 
 @Component({
@@ -34,6 +35,50 @@ interface MenuItem {
               <a [routerLink]="item.route" routerLinkActive="active" (click)="onNavigate()">
                 <span class="icon">{{ item.icon }}</span>
                 <span class="label">{{ item.label }}</span>
+              </a>
+            </li>
+            <li *ngFor="let c of clients">
+              <details>
+                <summary>
+                  <span class="icon">📁</span>
+                  <span class="label">{{ c.name }}</span>
+                </summary>
+                <ul>
+                  <li>
+                    <a [routerLink]="'/clients/' + c.id + '/actors'" routerLinkActive="active" (click)="onNavigate()">
+                      <span class="icon">🎭</span>
+                      <span class="label">Actores</span>
+                    </a>
+                  </li>
+                  <li *ngFor="let p of projectsByClient[c.id] || []">
+                    <details>
+                      <summary>
+                        <span class="icon">📂</span>
+                        <span class="label">{{ p.name }}</span>
+                      </summary>
+                      <ul>
+                        <li>
+                          <a [routerLink]="'/projects/' + p.id + '/scenarios'" routerLinkActive="active" (click)="onNavigate()">
+                            <span class="icon">📜</span>
+                            <span class="label">Escenarios</span>
+                          </a>
+                        </li>
+                        <li>
+                          <a [routerLink]="'/projects/' + p.id + '/features'" routerLinkActive="active" (click)="onNavigate()">
+                            <span class="icon">🌟</span>
+                            <span class="label">Features</span>
+                          </a>
+                        </li>
+                      </ul>
+                    </details>
+                  </li>
+                </ul>
+              </details>
+            </li>
+            <li>
+              <a [routerLink]="'/interactions'" routerLinkActive="active" (click)="onNavigate()">
+                <span class="icon">⚙️</span>
+                <span class="label">Interacciones</span>
               </a>
             </li>
           </ul>
@@ -64,6 +109,10 @@ interface MenuItem {
     .sidebar ul { list-style: none; margin: 0; padding: 0; }
     .sidebar li a { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1rem; text-decoration: none; color: var(--title-color); }
     .sidebar li a.active { background: var(--btn-primary); color: var(--btn-primary-text); }
+    .sidebar details { border-bottom: 1px solid var(--border-color); }
+    .sidebar details summary { cursor: pointer; padding: 0.5rem 1rem; display: flex; align-items: center; gap: 0.5rem; list-style: none; }
+    .sidebar details ul { list-style: none; margin: 0; padding: 0; }
+    .sidebar details ul li a { padding-left: 2rem; }
     .content { flex: 1; padding: 1rem; }
     .footer { text-align: center; padding: 0.5rem; background: var(--panel-bg); border-top: 1px solid var(--border-color); }
 
@@ -78,9 +127,10 @@ interface MenuItem {
 export class MainLayoutComponent implements OnInit {
   currentUser: User | null = null;
   menu: MenuItem[] = [
-    { label: 'Clientes', route: '/clients', icon: '🏢' },
-    { label: 'Actores', route: '/actors', icon: '🎭' }
+    { label: 'Clientes', route: '/clients', icon: '🏢' }
   ];
+  clients: Client[] = [];
+  projectsByClient: { [key: number]: Project[] } = {};
   sidebarOpen = false;
   userMenuOpen = false;
   headerTitle = 'GPTTester';
@@ -100,6 +150,26 @@ export class MainLayoutComponent implements OnInit {
         this.currentUser = u;
       });
     }
+    this.loadClients();
+  }
+
+  loadClients() {
+    this.api.getClients().subscribe(cs => {
+      this.clients = cs;
+      this.loadProjects();
+    });
+  }
+
+  loadProjects() {
+    this.api.getProjects().subscribe(ps => {
+      this.projectsByClient = {};
+      ps.forEach(p => {
+        if (!this.projectsByClient[p.client_id]) {
+          this.projectsByClient[p.client_id] = [];
+        }
+        this.projectsByClient[p.client_id].push(p);
+      });
+    });
   }
 
   toggleSidebar() {

--- a/frontend/src/app/components/projects/projects.component.ts
+++ b/frontend/src/app/components/projects/projects.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-projects',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Proyectos</h1>
+      <p *ngIf="clientId">Cliente ID: {{ clientId }}</p>
+    </div>
+  `
+})
+export class ProjectsComponent implements OnInit {
+  clientId: number | null = null;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    const cid = this.route.snapshot.paramMap.get('clientId');
+    this.clientId = cid ? Number(cid) : null;
+  }
+}

--- a/frontend/src/app/components/scenario-data/scenario-data.component.ts
+++ b/frontend/src/app/components/scenario-data/scenario-data.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-scenario-data',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Datos de Escenario</h1>
+      <p>Escenario ID: {{ scenarioId }}</p>
+    </div>
+  `
+})
+export class ScenarioDataComponent implements OnInit {
+  scenarioId!: number;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.scenarioId = Number(this.route.snapshot.paramMap.get('scenarioId'));
+  }
+}

--- a/frontend/src/app/components/scenarios/scenarios.component.ts
+++ b/frontend/src/app/components/scenarios/scenarios.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-scenarios',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Escenarios</h1>
+      <p>Proyecto ID: {{ projectId }}</p>
+    </div>
+  `
+})
+export class ScenariosComponent implements OnInit {
+  projectId!: number;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.projectId = Number(this.route.snapshot.paramMap.get('projectId'));
+  }
+}

--- a/frontend/src/app/components/tasks/tasks.component.ts
+++ b/frontend/src/app/components/tasks/tasks.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-tasks',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="main-panel">
+      <h1>Tareas</h1>
+      <p>Escenario ID: {{ scenarioId }}</p>
+    </div>
+  `
+})
+export class TasksComponent implements OnInit {
+  scenarioId!: number;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.scenarioId = Number(this.route.snapshot.paramMap.get('scenarioId'));
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder routes for projects, scenarios, tasks, scenario data, features and interactions
- fetch projects per client and nest them in the sidebar
- link to scenarios and features under each project
- provide empty components for the new views

## Testing
- `npm install`
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6864798466e4832f81e5076624abedd7