### PR TITLE
Fix admin login redirect

### DIFF
--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -177,7 +177,15 @@ export class LoginComponent {
     this.apiService.login(this.credentials).subscribe({
       next: () => {
         this.isLoading = false;
-        this.router.navigate(['/clients']);
+        this.apiService.getCurrentUser().subscribe({
+          next: (u) => {
+            const target = u.role?.name === 'Administrador' ? '/users' : '/clients';
+            this.router.navigate([target]);
+          },
+          error: () => {
+            this.router.navigate(['/clients']);
+          }
+        });
       },
       error: (error) => {
         this.isLoading = false;


### PR DESCRIPTION
## Summary
- redirect Administrador users to /users after login

## Testing
- `pytest -q` *(fails: AttributeError: module 'backend.app.models' has no attribute 'AuditEvent' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68647dcb9294832f9c717ac53131a731