### PR TITLE
Fix admin menu items

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -44,6 +44,25 @@ export const routes: Routes = [
         loadComponent: () => import('./components/features/features.component').then(m => m.FeaturesComponent)
       },
       {
+        path: 'dashboard',
+        loadComponent: () => import('./components/dashboard/dashboard.component').then(m => m.DashboardComponent)
+      },
+      {
+        path: 'users',
+        loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent),
+        canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
+      },
+      {
+        path: 'roles',
+        loadComponent: () => import('./components/roles/roles.component').then(m => m.RolesComponent),
+        canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
+      },
+      {
+        path: 'agents',
+        loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent),
+        canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
+      },
+      {
         path: 'interactions',
         loadComponent: () => import('./components/interactions/interactions.component').then(m => m.InteractionsComponent)
       }

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -121,9 +121,7 @@ interface MenuItem {
 })
 export class MainLayoutComponent implements OnInit {
   currentUser: User | null = null;
-  menu: MenuItem[] = [
-    { label: 'Clientes', route: '/clients', icon: '🏢' }
-  ];
+  menu: MenuItem[] = [];
   clients: Client[] = [];
   projectsByClient: { [key: number]: Project[] } = {};
   sidebarOpen = false;
@@ -134,6 +132,27 @@ export class MainLayoutComponent implements OnInit {
     private router: Router
   ) {}
 
+  buildMenu() {
+    const base = [
+      { label: 'Clientes', route: '/clients', icon: '🏢' }
+    ];
+    const extra = [
+      { label: 'Interacciones', route: '/interactions', icon: '⚙️' }
+    ];
+    const admin = [
+      { label: 'Dashboard', route: '/dashboard', icon: '🏠' },
+      { label: 'Usuarios', route: '/users', icon: '👥' },
+      { label: 'Roles', route: '/roles', icon: '🛡️' },
+      { label: 'Agentes', route: '/agents', icon: '🤖' }
+    ];
+
+    if (this.currentUser?.role?.name === 'Administrador') {
+      this.menu = [...admin, ...base, ...extra];
+    } else {
+      this.menu = [...base, ...extra];
+    }
+  }
+
   get isMobile(): boolean {
     return window.innerWidth <= 768;
   }
@@ -142,8 +161,10 @@ export class MainLayoutComponent implements OnInit {
     if (this.api.isAuthenticated()) {
       this.api.getCurrentUser().subscribe(u => {
         this.currentUser = u;
+        this.buildMenu();
       });
     }
+    this.buildMenu();
     this.loadClients();
   }
 


### PR DESCRIPTION
## Summary
- show admin links in sidebar
- add dashboard and admin routes

## Testing
- `pytest -q` *(fails: AuditEvent attribute error and other API 404s)*

------
https://chatgpt.com/codex/tasks/task_e_68647deb55c4832f94a282f37f3682b9