### PR TITLE
Add admin user toggle checkbox

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -348,3 +348,19 @@ def assign_role(
     db.commit()
     db.refresh(user)
     return user
+
+
+@app.put("/users/{user_id}/active", response_model=schemas.User)
+def update_user_active(
+    user_id: int,
+    payload: schemas.UserActiveUpdate,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(deps.require_admin),
+):
+    user = db.query(models.User).filter_by(id=user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    user.is_active = payload.is_active
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -27,6 +27,10 @@ class User(BaseModel):
         orm_mode = True
 
 
+class UserActiveUpdate(BaseModel):
+    is_active: bool
+
+
 # 3️⃣ PagePermissions
 class PagePermission(BaseModel):
     id: int

--- a/frontend/src/app/components/users/users.component.ts
+++ b/frontend/src/app/components/users/users.component.ts
@@ -17,7 +17,7 @@ import { ApiService } from '../../services/api.service';
       <button class="btn btn-primary mb-2" routerLink="/register">Registrar Usuario</button>
       <table class="table" *ngIf="users.length > 0">
         <thead>
-          <tr><th>Username</th><th>Rol</th><th>Último Login</th><th>Activo</th><th></th></tr>
+          <tr><th>Username</th><th>Rol</th><th>Último Login</th><th>Activo</th></tr>
         </thead>
         <tbody>
           <tr *ngFor="let u of users">
@@ -28,11 +28,11 @@ import { ApiService } from '../../services/api.service';
               </select>
             </td>
             <td>{{ u.last_login ? (u.last_login | date:'short') : '-' }}</td>
-            <td>{{ u.is_active ? 'Sí' : 'No' }}</td>
             <td>
-              <button class="btn btn-sm btn-secondary" (click)="toggleActive(u)" [disabled]="u.id === currentUserId">
-                {{ u.is_active ? 'Desactivar' : 'Activar' }}
-              </button>
+              <input type="checkbox"
+                     [checked]="u.is_active"
+                     (change)="toggleActive(u, $event)"
+                     [disabled]="u.id === currentUserId" />
             </td>
           </tr>
         </tbody>
@@ -68,8 +68,10 @@ export class UsersComponent implements OnInit {
     this.userService.updateUserRole(user.id, { role_id: user.role.id }).subscribe();
   }
 
-  toggleActive(user: User) {
-    this.userService.updateUserActive(user.id, !user.is_active).subscribe(u => user.is_active = u.is_active);
+  toggleActive(user: User, event?: Event) {
+    const checked = event ? (event.target as HTMLInputElement).checked : !user.is_active;
+    this.userService.updateUserActive(user.id, checked)
+      .subscribe(u => user.is_active = u.is_active);
   }
 
   get currentUserId(): number | null {


### PR DESCRIPTION
## Summary
- allow admins to toggle a user's active status via checkbox
- backend endpoint `/users/{user_id}/active` to update active flag

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError and 404 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686480340964832f95f9d3f71338c99a