### PR TITLE
Enable role activation toggle

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -348,3 +348,19 @@ def assign_role(
     db.commit()
     db.refresh(user)
     return user
+
+
+@app.put("/roles/{role_id}/active", response_model=schemas.Role)
+def update_role_active(
+    role_id: int,
+    data: dict,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(deps.require_admin),
+):
+    role = db.query(models.Role).filter_by(id=role_id).first()
+    if not role:
+        raise HTTPException(status_code=404, detail="Not found")
+    role.is_active = bool(data.get("is_active"))
+    db.commit()
+    db.refresh(role)
+    return role

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -8,6 +8,7 @@ class Role(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), unique=True, nullable=False)
     description = Column(Text)
+    is_active = Column(Boolean, default=True)
 
     users = relationship("User", back_populates="role")
     page_permissions = relationship("PagePermission", back_populates="role")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,7 @@ class Role(BaseModel):
     id: int
     name: str
     description: str
+    is_active: bool = True
 
     class Config:
         orm_mode = True

--- a/frontend/src/app/components/roles/role-form.component.ts
+++ b/frontend/src/app/components/roles/role-form.component.ts
@@ -17,6 +17,10 @@ import { RoleService } from '../../services/role.service';
             <label class="form-label">Nombre</label>
             <input class="form-control" [(ngModel)]="form.name" name="name" required>
           </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="active" [(ngModel)]="form.is_active" name="is_active">
+            <label class="form-check-label" for="active">Activo</label>
+          </div>
           <button class="btn btn-primary" type="submit">Guardar</button>
           <button type="button" class="btn btn-secondary ms-2" (click)="cancel.emit()">Cancelar</button>
         </form>
@@ -29,13 +33,13 @@ export class RoleFormComponent {
   @Output() saved = new EventEmitter<void>();
   @Output() cancel = new EventEmitter<void>();
 
-  form: RoleCreate = { name: '' };
+  form: RoleCreate = { name: '', is_active: true };
 
   constructor(private service: RoleService) {}
 
   ngOnInit() {
     if (this.role) {
-      this.form = { name: this.role.name };
+      this.form = { name: this.role.name, is_active: this.role.is_active };
     }
   }
 

--- a/frontend/src/app/components/roles/roles.component.ts
+++ b/frontend/src/app/components/roles/roles.component.ts
@@ -15,11 +15,14 @@ import { RoleFormComponent } from './role-form.component';
       <button class="btn btn-primary mb-2" (click)="new()">Nuevo Rol</button>
       <table class="table" *ngIf="roles.length > 0">
         <thead>
-          <tr><th>Nombre</th><th></th></tr>
+          <tr><th>Nombre</th><th>Activo</th><th></th></tr>
         </thead>
         <tbody>
           <tr *ngFor="let r of roles">
             <td>{{ r.name }}</td>
+            <td>
+              <input class="form-check-input" type="checkbox" [checked]="r.is_active" (change)="toggleActive(r, $any($event.target).checked)">
+            </td>
             <td>
               <button class="btn btn-sm btn-secondary me-2" (click)="edit(r)">Editar</button>
               <button class="btn btn-sm btn-danger" (click)="remove(r)">Eliminar</button>
@@ -56,6 +59,10 @@ export class RolesComponent implements OnInit {
     if (confirm('¿Eliminar rol?')) {
       this.service.deleteRole(r.id).subscribe(() => this.load());
     }
+  }
+
+  toggleActive(role: Role, active: boolean) {
+    this.service.updateRoleActive(role.id, active).subscribe(r => role.is_active = r.is_active);
   }
 
   onSaved() {

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -1,6 +1,7 @@
 export interface Role {
   id: number;
   name: string;
+  is_active: boolean;
 }
 
 export interface User {
@@ -150,6 +151,7 @@ export interface PendingExecution {
 // DTOs para creación
 export interface RoleCreate {
   name: string;
+  is_active?: boolean;
 }
 
 export interface UserCreate {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -77,6 +77,10 @@ export class ApiService {
     return this.http.put<Role>(`${this.baseUrl}/roles/${id}`, role, { headers: this.getHeaders() });
   }
 
+  updateRoleActive(id: number, isActive: boolean): Observable<Role> {
+    return this.http.put<Role>(`${this.baseUrl}/roles/${id}/active`, { is_active: isActive }, { headers: this.getHeaders() });
+  }
+
   deleteRole(id: number): Observable<any> {
     return this.http.delete(`${this.baseUrl}/roles/${id}`, { headers: this.getHeaders() });
   }

--- a/frontend/src/app/services/role.service.ts
+++ b/frontend/src/app/services/role.service.ts
@@ -19,6 +19,10 @@ export class RoleService {
     return this.api.updateRole(id, role);
   }
 
+  updateRoleActive(id: number, isActive: boolean): Observable<Role> {
+    return this.api.updateRoleActive(id, isActive);
+  }
+
   deleteRole(id: number): Observable<any> {
     return this.api.deleteRole(id);
   }


### PR DESCRIPTION
## Summary
- add `is_active` field to backend Role model and schema
- expose `/roles/{role_id}/active` endpoint to update role state
- extend API and Role services for role activation control
- update role form and list UI with active checkbox
- include new property in TypeScript interfaces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68648051a31c832f8b6c041afc5e6c2f