### PR TITLE
Add UI to manage role permissions

### DIFF
--- a/frontend/src/app/components/roles/role-permissions.component.ts
+++ b/frontend/src/app/components/roles/role-permissions.component.ts
@@ -1,0 +1,153 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Role, PagePermission, PagePermissionCreate, ApiPermission, ApiPermissionCreate } from '../../models';
+import { RoleService } from '../../services/role.service';
+
+@Component({
+  selector: 'app-role-permissions',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="modal" (click)="close.emit()">
+      <div class="modal-content" (click)="$event.stopPropagation()">
+        <div class="modal-header">
+          <h3>Permisos de {{ role?.name }}</h3>
+          <button class="btn-close" (click)="close.emit()">×</button>
+        </div>
+        <div class="modal-body">
+          <h4>Páginas</h4>
+          <div *ngFor="let p of pages" class="perm-row">
+            <span>{{ p.page }}</span>
+            <button class="btn btn-sm btn-danger" (click)="removePage(p)">Quitar</button>
+          </div>
+          <form class="d-flex mb-3" (ngSubmit)="addPage()">
+            <input class="form-control me-2" placeholder="/ruta" [(ngModel)]="newPage.page" name="page" required>
+            <button class="btn btn-primary btn-sm" type="submit">Agregar</button>
+          </form>
+          <h4>APIs</h4>
+          <div *ngFor="let a of apis" class="perm-row">
+            <span>{{ a.method }} {{ a.route }}</span>
+            <button class="btn btn-sm btn-danger" (click)="removeApi(a)">Quitar</button>
+          </div>
+          <form class="d-flex mb-3" (ngSubmit)="addApi()">
+            <input class="form-control me-2" placeholder="/api/ruta" [(ngModel)]="newApi.route" name="route" required>
+            <select class="form-select me-2" [(ngModel)]="newApi.method" name="method" required>
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="DELETE">DELETE</option>
+            </select>
+            <button class="btn btn-primary btn-sm" type="submit">Agregar</button>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" (click)="close.emit()">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    .modal-content {
+      background: white;
+      border-radius: 10px;
+      width: 90%;
+      max-width: 600px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 20px;
+      border-bottom: 1px solid #eee;
+    }
+    .modal-body {
+      padding: 20px;
+    }
+    .perm-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 4px 0;
+    }
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      padding: 20px;
+      border-top: 1px solid #eee;
+    }
+    .btn-close {
+      background: none;
+      border: none;
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+  `]
+})
+export class RolePermissionsComponent implements OnChanges {
+  @Input() role!: Role;
+  @Output() close = new EventEmitter<void>();
+
+  pages: PagePermission[] = [];
+  apis: ApiPermission[] = [];
+
+  newPage: PagePermissionCreate = { page: '' };
+  newApi: ApiPermissionCreate = { route: '', method: 'GET' };
+
+  constructor(private service: RoleService) {}
+
+  ngOnChanges() {
+    if (this.role) {
+      this.load();
+    }
+  }
+
+  load() {
+    this.service.getPagePermissions(this.role.id).subscribe(p => this.pages = p);
+    this.service.getApiPermissions(this.role.id).subscribe(a => this.apis = a);
+  }
+
+  addPage() {
+    if (!this.newPage.page) return;
+    this.service.addPagePermission(this.role.id, this.newPage).subscribe(p => {
+      this.pages.push(p);
+      this.newPage = { page: '' };
+    });
+  }
+
+  removePage(p: PagePermission) {
+    if (!confirm('¿Quitar permiso?')) return;
+    this.service.deletePagePermission(this.role.id, p.page).subscribe(() => {
+      this.pages = this.pages.filter(x => x.id !== p.id);
+    });
+  }
+
+  addApi() {
+    if (!this.newApi.route || !this.newApi.method) return;
+    this.service.addApiPermission(this.role.id, this.newApi).subscribe(a => {
+      this.apis.push(a);
+      this.newApi = { route: '', method: 'GET' };
+    });
+  }
+
+  removeApi(a: ApiPermission) {
+    if (!confirm('¿Quitar permiso?')) return;
+    this.service.deleteApiPermission(this.role.id, a.id).subscribe(() => {
+      this.apis = this.apis.filter(x => x.id !== a.id);
+    });
+  }
+}

--- a/frontend/src/app/components/roles/roles.component.ts
+++ b/frontend/src/app/components/roles/roles.component.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { Role } from '../../models';
 import { RoleService } from '../../services/role.service';
 import { RoleFormComponent } from './role-form.component';
+import { RolePermissionsComponent } from './role-permissions.component';
 
 @Component({
   selector: 'app-roles',
   standalone: true,
-  imports: [CommonModule, FormsModule, RoleFormComponent],
+  imports: [CommonModule, FormsModule, RoleFormComponent, RolePermissionsComponent],
   template: `
     <div class="main-panel">
       <h1>Roles</h1>
@@ -22,6 +23,7 @@ import { RoleFormComponent } from './role-form.component';
             <td>{{ r.name }}</td>
             <td>
               <button class="btn btn-sm btn-secondary me-2" (click)="edit(r)">Editar</button>
+              <button class="btn btn-sm btn-info me-2" (click)="permissions(r)">Permisos</button>
               <button class="btn btn-sm btn-danger" (click)="remove(r)">Eliminar</button>
             </td>
           </tr>
@@ -30,6 +32,7 @@ import { RoleFormComponent } from './role-form.component';
       <div *ngIf="roles.length === 0">No hay roles.</div>
 
       <app-role-form *ngIf="showForm" [role]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-role-form>
+      <app-role-permissions *ngIf="selectedRole" [role]="selectedRole" (close)="selectedRole=null"></app-role-permissions>
     </div>
   `
 })
@@ -37,6 +40,7 @@ export class RolesComponent implements OnInit {
   roles: Role[] = [];
   showForm = false;
   editing: Role | null = null;
+  selectedRole: Role | null = null;
 
   constructor(private service: RoleService) {}
 
@@ -51,6 +55,8 @@ export class RolesComponent implements OnInit {
   new() { this.editing = null; this.showForm = true; }
 
   edit(r: Role) { this.editing = r; this.showForm = true; }
+
+  permissions(r: Role) { this.selectedRole = r; }
 
   remove(r: Role) {
     if (confirm('¿Eliminar rol?')) {

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -274,6 +274,34 @@ export interface MarketplaceComponentCreate {
   version?: string;
 }
 
+export interface PagePermission {
+  id: number;
+  page: string;
+  role_id: number;
+  isStartPage: boolean;
+  description?: string;
+}
+
+export interface PagePermissionCreate {
+  page: string;
+  isStartPage?: boolean;
+  description?: string;
+}
+
+export interface ApiPermission {
+  id: number;
+  route: string;
+  method: string;
+  role_id: number;
+  description?: string;
+}
+
+export interface ApiPermissionCreate {
+  route: string;
+  method: string;
+  description?: string;
+}
+
 export interface ApiResponse<T> {
   data?: T;
   error?: string;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -10,7 +10,8 @@ import {
   TestPlanCreate, PageCreate, PageElementCreate, ActionCreate,
   ActionAssignmentCreate, Actor, ActorCreate, AgentCreate, ExecutionPlanCreate,
   LoginRequest, LoginResponse, UserRoleUpdate, PendingExecution,
-  MarketplaceComponent, MarketplaceComponentCreate
+  MarketplaceComponent, MarketplaceComponentCreate,
+  PagePermission, PagePermissionCreate, ApiPermission, ApiPermissionCreate
 } from '../models';
 
 @Injectable({
@@ -259,6 +260,32 @@ export class ApiService {
 
   deletePage(id: number): Observable<any> {
     return this.http.delete(`${this.baseUrl}/pages/${id}`, { headers: this.getHeaders() });
+  }
+
+  // Role permissions
+  getPagePermissions(roleId: number): Observable<PagePermission[]> {
+    return this.http.get<PagePermission[]>(`${this.baseUrl}/roles/${roleId}/permissions`, { headers: this.getHeaders() });
+  }
+
+  addPagePermission(roleId: number, perm: PagePermissionCreate): Observable<PagePermission> {
+    return this.http.post<PagePermission>(`${this.baseUrl}/roles/${roleId}/permissions`, perm, { headers: this.getHeaders() });
+  }
+
+  deletePagePermission(roleId: number, page: string): Observable<any> {
+    const encoded = encodeURIComponent(page);
+    return this.http.delete(`${this.baseUrl}/roles/${roleId}/permissions/${encoded}`, { headers: this.getHeaders() });
+  }
+
+  getApiPermissions(roleId: number): Observable<ApiPermission[]> {
+    return this.http.get<ApiPermission[]>(`${this.baseUrl}/roles/${roleId}/api-permissions`, { headers: this.getHeaders() });
+  }
+
+  addApiPermission(roleId: number, perm: ApiPermissionCreate): Observable<ApiPermission> {
+    return this.http.post<ApiPermission>(`${this.baseUrl}/roles/${roleId}/api-permissions`, perm, { headers: this.getHeaders() });
+  }
+
+  deleteApiPermission(roleId: number, permId: number): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/roles/${roleId}/api-permissions/${permId}`, { headers: this.getHeaders() });
   }
 
   // Page Elements

--- a/frontend/src/app/services/role.service.ts
+++ b/frontend/src/app/services/role.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
-import { Role, RoleCreate } from '../models';
+import { Role, RoleCreate, PagePermission, PagePermissionCreate, ApiPermission, ApiPermissionCreate } from '../models';
 
 @Injectable({ providedIn: 'root' })
 export class RoleService {
@@ -21,5 +21,29 @@ export class RoleService {
 
   deleteRole(id: number): Observable<any> {
     return this.api.deleteRole(id);
+  }
+
+  getPagePermissions(roleId: number): Observable<PagePermission[]> {
+    return this.api.getPagePermissions(roleId);
+  }
+
+  addPagePermission(roleId: number, perm: PagePermissionCreate): Observable<PagePermission> {
+    return this.api.addPagePermission(roleId, perm);
+  }
+
+  deletePagePermission(roleId: number, page: string): Observable<any> {
+    return this.api.deletePagePermission(roleId, page);
+  }
+
+  getApiPermissions(roleId: number): Observable<ApiPermission[]> {
+    return this.api.getApiPermissions(roleId);
+  }
+
+  addApiPermission(roleId: number, perm: ApiPermissionCreate): Observable<ApiPermission> {
+    return this.api.addApiPermission(roleId, perm);
+  }
+
+  deleteApiPermission(roleId: number, permId: number): Observable<any> {
+    return this.api.deleteApiPermission(roleId, permId);
   }
 }


### PR DESCRIPTION
## Summary
- allow viewing and editing a role's page and API permissions
- show modern modal to manage permissions

## Testing
- `pytest -q` *(fails: AttributeError and 404s in API tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864807f8974832f845b7d5383f32fa2