### PR TITLE
Ensure backend seeds default users

### DIFF
--- a/backend/README2.md
+++ b/backend/README2.md
@@ -43,11 +43,11 @@ Al iniciar la aplicación se crean automáticamente los roles:
 - Gerente de servicios
 
 También se genera el usuario inicial `admin` con la contraseña `admin` perteneciente al rol **Administrador**.
-Además, se crean tres usuarios predeterminados:
+- Al iniciarse el backend se aseguran además estos usuarios con la contraseña `admin`:
 
-- `architect` con rol **Arquitecto de Automatización** (contraseña `architect`)
-- `service_manager` con rol **Gerente de servicios** (contraseña `service_manager`)
-- `test_automator` con rol **Automatizador de Pruebas** (contraseña `test_automator`)
+- `architect` con rol **Arquitecto de Automatización**
+- `AngelC` con rol **Gerente de servicios**
+- `T23AutoPerson` con rol **Automatizador de Pruebas**
 
 Ahora cada rol puede tener permisos asociados a las páginas del frontend. Usa los siguientes endpoints para administrarlos:
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,6 +111,22 @@ def seed_database() -> None:
                 )
             )
 
+        default_users = [
+            ("architect", "Arquitecto de Automatización"),
+            ("AngelC", "Gerente de servicios"),
+            ("T23AutoPerson", "Automatizador de Pruebas"),
+        ]
+        for username, role_name in default_users:
+            role = role_map.get(role_name)
+            if role and not db.query(models.User).filter_by(username=username).first():
+                db.add(
+                    models.User(
+                        username=username,
+                        password=deps.get_password_hash("admin"),
+                        role_id=role.id,
+                    )
+                )
+
         db.commit()
         logger.info("Database seed commit successful")
     finally:


### PR DESCRIPTION
## Summary
- seed additional default users if missing (architect, AngelC, T23AutoPerson)
- document new default users in backend README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError and 404 test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864800bac14832f9528a262a25efddf