### PR TITLE
Fix missing current user endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -248,7 +248,13 @@ def register_cruds():
         app.include_router(create_crud_router(prefix, model, schema))
 
 
+
 register_cruds()
+
+
+@app.get("/users/me/", response_model=schemas.User)
+def read_current_user(current_user: models.User = Depends(deps.get_current_user)):
+    return current_user
 
 
 @app.get("/permissions")

--- a/tests/test_current_user.py
+++ b/tests/test_current_user.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def login() -> str:
+    resp = client.post("/token", data={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_get_current_user():
+    token = login()
+    resp = client.get("/users/me/", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == "admin"


### PR DESCRIPTION
## Summary
- implement `/users/me/` API to fetch the authenticated user
- add regression test for this endpoint

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError module 'backend.app.models' has no attribute 'AuditEvent', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864855a8ff0832f9323acabad57c065