### PR TITLE
Allow admin user to bypass API permission checks

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -104,6 +104,8 @@ def require_api_permission(route: str, method: str):
         current_user: models.User = Depends(get_current_user),
         db: Session = Depends(get_db),
     ):
+        if current_user.role.name == "Administrador":
+            return
         perms = (
             db.query(models.ApiPermission).filter_by(route=route, method=method).all()
         )


### PR DESCRIPTION
## Summary
- let administrators call any backend API by skipping API permission checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6864853c5574832fbb12016abbf6cc2b