### PR TITLE
Fix admin sidebar menu

### DIFF
--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -73,12 +73,6 @@ interface MenuItem {
                 </ul>
               </details>
             </li>
-            <li>
-              <a [routerLink]="'/interactions'" routerLinkActive="active" (click)="onNavigate()">
-                <span class="icon">⚙️</span>
-                <span class="label">Interacciones</span>
-              </a>
-            </li>
           </ul>
         </nav>
         <main class="content">
@@ -163,8 +157,9 @@ export class MainLayoutComponent implements OnInit {
         this.currentUser = u;
         this.buildMenu();
       });
+    } else {
+      this.buildMenu();
     }
-    this.buildMenu();
     this.loadClients();
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate `Interacciones` entry in sidebar
- rebuild menu only after user information is available

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686485771fe4832faf6e8da733a8e19e