### PR TITLE
Fix auth redirect

### DIFF
--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpErrorResponse
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ApiService } from './services/api.service';
+import { Router } from '@angular/router';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private api: ApiService, private router: Router) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 401) {
+          this.api.clearSession();
+          this.router.navigate(['/login']);
+        }
+        return throwError(() => err);
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -52,14 +52,17 @@ export class ApiService {
     this.http.post(`${this.baseUrl}/logout`, {}, { headers: this.getHeaders() })
       .subscribe({
         complete: () => {
-          localStorage.removeItem('token');
-          this.tokenSubject.next(null);
+          this.clearSession();
         },
         error: () => {
-          localStorage.removeItem('token');
-          this.tokenSubject.next(null);
+          this.clearSession();
         }
       });
+  }
+
+  clearSession(): void {
+    localStorage.removeItem('token');
+    this.tokenSubject.next(null);
   }
 
   getCurrentUser(): Observable<User> {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,6 +6,7 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 import { routes } from './app/app.routes';
 import { WorkspaceInterceptor } from './app/workspace.interceptor';
+import { AuthInterceptor } from './app/auth.interceptor';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -17,6 +18,11 @@ bootstrapApplication(AppComponent, {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: WorkspaceInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
       multi: true
     }
   ]


### PR DESCRIPTION
## Summary
- add `AuthInterceptor` to catch HTTP 401
- centralize session removal in `ApiService`
- register new interceptor so invalid sessions redirect to login

## Testing
- `npm test` *(fails: ng not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864863e0e7c832fbb80f7d88a41998a