### PR TITLE
Fix admin sidebar menu

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -58,6 +58,11 @@ export const routes: Routes = [
         canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
       },
       {
+        path: 'permissions',
+        loadComponent: () => import('./components/permissions/permissions.component').then(m => m.PermissionsComponent),
+        canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
+      },
+      {
         path: 'agents',
         loadComponent: () => import('./components/agents/agents.component').then(m => m.AgentsComponent),
         canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -73,12 +73,6 @@ interface MenuItem {
                 </ul>
               </details>
             </li>
-            <li>
-              <a [routerLink]="'/interactions'" routerLinkActive="active" (click)="onNavigate()">
-                <span class="icon">⚙️</span>
-                <span class="label">Interacciones</span>
-              </a>
-            </li>
           </ul>
         </nav>
         <main class="content">
@@ -143,6 +137,7 @@ export class MainLayoutComponent implements OnInit {
       { label: 'Dashboard', route: '/dashboard', icon: '🏠' },
       { label: 'Usuarios', route: '/users', icon: '👥' },
       { label: 'Roles', route: '/roles', icon: '🛡️' },
+      { label: 'Permisos', route: '/permissions', icon: '🔑' },
       { label: 'Agentes', route: '/agents', icon: '🤖' }
     ];
 
@@ -163,8 +158,9 @@ export class MainLayoutComponent implements OnInit {
         this.currentUser = u;
         this.buildMenu();
       });
+    } else {
+      this.buildMenu();
     }
-    this.buildMenu();
     this.loadClients();
   }
 

--- a/frontend/src/app/components/permissions/permissions.component.ts
+++ b/frontend/src/app/components/permissions/permissions.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-permissions',
+  standalone: true,
+  template: `
+    <div class="main-panel">
+      <h1>Permisos</h1>
+      <p>Gestiona permisos desde la sección de roles.</p>
+    </div>
+  `,
+})
+export class PermissionsComponent {}


### PR DESCRIPTION
## Summary
- remove duplicate `Interacciones` entry in sidebar
- rebuild menu only after user information is available
- add `Permisos` option with route for admin users

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_686485771fe4832faf6e8da733a8e19e