### PR TITLE
Fix schemas optional fields

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,7 +7,7 @@ from datetime import datetime
 class Role(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
     is_active: bool = True
 
     class Config:
@@ -38,7 +38,7 @@ class PagePermission(BaseModel):
     page: str
     role_id: int
     isStartPage: bool
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True
@@ -50,7 +50,7 @@ class ApiPermission(BaseModel):
     route: str
     method: str
     role_id: int
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True
@@ -74,9 +74,9 @@ class Client(BaseModel):
     idGerente: Optional[int]
     name: str
     is_active: bool
-    mision: str
-    vision: str
-    paginaInicio: str
+    mision: Optional[str]
+    vision: Optional[str]
+    paginaInicio: Optional[str]
     dedication: Optional[int]
 
     class Config:
@@ -87,9 +87,9 @@ class Client(BaseModel):
 class BusinessAgreement(BaseModel):
     id: int
     clientId: int
-    description: str
-    okr: str
-    kpi: str
+    description: Optional[str]
+    okr: Optional[str]
+    kpi: Optional[str]
 
     class Config:
         orm_mode = True
@@ -99,9 +99,9 @@ class BusinessAgreement(BaseModel):
 class DigitalAsset(BaseModel):
     id: int
     clientId: int
-    description: str
-    okr: str
-    kpi: str
+    description: Optional[str]
+    okr: Optional[str]
+    kpi: Optional[str]
 
     class Config:
         orm_mode = True
@@ -111,7 +111,7 @@ class DigitalAsset(BaseModel):
 class UserInterface(BaseModel):
     id: int
     digitalAssetsId: int
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -121,7 +121,7 @@ class UserInterface(BaseModel):
 # 9️⃣ ElementType
 class ElementType(BaseModel):
     id: int
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -133,7 +133,7 @@ class Element(BaseModel):
     id: int
     userInterfaceId: int
     elementTypeId: int
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -192,7 +192,7 @@ class Interaction(BaseModel):
     code: str
     name: str
     requireReview: bool
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True
@@ -203,7 +203,7 @@ class InteractionParameter(BaseModel):
     id: int
     interactionId: int
     name: str
-    description: str
+    description: Optional[str]
     direction: bool
 
     class Config:
@@ -214,7 +214,7 @@ class InteractionParameter(BaseModel):
 class InteractionApprovalState(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True
@@ -226,7 +226,7 @@ class InteractionApproval(BaseModel):
     interactionId: int
     creatorId: int
     aprovalUserId: int
-    comment: str
+    comment: Optional[str]
     interactionAprovalStateId: int
     aprovalDate: Optional[datetime]
     creationDate: Optional[datetime]
@@ -239,7 +239,7 @@ class InteractionApproval(BaseModel):
 class Task(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -264,7 +264,7 @@ class Validation(BaseModel):
     code: str
     name: str
     requireReview: bool
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True
@@ -275,7 +275,7 @@ class ValidationParameter(BaseModel):
     id: int
     interactionId: int
     name: str
-    description: str
+    description: Optional[str]
     direction: bool
 
     class Config:
@@ -288,7 +288,7 @@ class ValidationApproval(BaseModel):
     validationId: int
     creatorId: int
     aprovalUserId: int
-    comment: str
+    comment: Optional[str]
     interactionAprovalStateId: int
     aprovalDate: Optional[datetime]
     creationDate: Optional[datetime]
@@ -301,7 +301,7 @@ class ValidationApproval(BaseModel):
 class Question(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -322,7 +322,7 @@ class QuestionHasValidation(BaseModel):
 class Scenario(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -359,7 +359,7 @@ class FieldType(BaseModel):
     id: int
     name: str
     format: Optional[str]
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:
@@ -370,7 +370,7 @@ class FieldType(BaseModel):
 class Feature(BaseModel):
     id: int
     name: str
-    description: str
+    description: Optional[str]
     status: bool
 
     class Config:


### PR DESCRIPTION
## Summary
- update many field types to Optional in `schemas.py`
- ensure pydantic schemas mirror SQLAlchemy models

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6865396046f0832fabf457bb4caef82e