### PR TITLE
Fix CRUD for clients, digital assets and projects

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from .database import engine, SessionLocal
 from . import models, schemas, deps
 from .crud import create_crud_router
+from .routes import all_routers
 
 logger = logging.getLogger(__name__)
 
@@ -190,13 +191,10 @@ def register_cruds():
         ("users", models.User, schemas.User),
         ("pagepermissions", models.PagePermission, schemas.PagePermission),
         ("apipermissions", models.ApiPermission, schemas.ApiPermission),
-        ("clients", models.Client, schemas.Client),
         ("businessagreements", models.BusinessAgreement, schemas.BusinessAgreement),
-        ("digitalassets", models.DigitalAsset, schemas.DigitalAsset),
         ("userinterfaces", models.UserInterface, schemas.UserInterface),
         ("elementtypes", models.ElementType, schemas.ElementType),
         ("elements", models.Element, schemas.Element),
-        ("projects", models.Project, schemas.Project),
         ("projectemployees", models.ProjectEmployee, schemas.ProjectEmployee),
         ("actors", models.Actor, schemas.Actor),
         ("habilities", models.Hability, schemas.Hability),
@@ -250,6 +248,8 @@ def register_cruds():
 
 
 register_cruds()
+for r in all_routers:
+    app.include_router(r)
 
 
 @app.get("/users/me/", response_model=schemas.User)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,7 @@
+from . import clients, digital_assets, projects
+
+all_routers = [
+    clients.router,
+    digital_assets.router,
+    projects.router,
+]

--- a/backend/app/routes/clients.py
+++ b/backend/app/routes/clients.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, deps
+
+router = APIRouter(prefix="/clients", tags=["clients"])
+
+
+# Dependency to require Service Manager role
+
+def require_service_manager(
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    if current_user.role.name != "Gerente de servicios" and current_user.role.name != "Administrador":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Manager only")
+    return current_user
+
+
+@router.post("/", response_model=schemas.Client)
+def create_client(
+    client: schemas.Client,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    if not client.name or not client.mision or not client.vision:
+        raise HTTPException(status_code=400, detail="Missing required fields")
+    db_obj = models.Client(**client.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=list[schemas.Client])
+def list_clients(
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    if current_user.role.name in ["Analista de Pruebas con skill de automatización", "Automatizador de Pruebas"]:
+        projects = (
+            db.query(models.Project)
+            .join(models.ProjectEmployee, models.Project.id == models.ProjectEmployee.projectId)
+            .filter(models.ProjectEmployee.userId == current_user.id)
+            .all()
+        )
+        client_ids = {p.digitalAssetsId for p in projects}
+        # map digital asset -> client
+        assets = db.query(models.DigitalAsset).filter(models.DigitalAsset.id.in_(client_ids)).all()
+        allowed_clients = {a.clientId for a in assets}
+        return db.query(models.Client).filter(models.Client.id.in_(allowed_clients)).all()
+    return db.query(models.Client).all()
+
+
+@router.get("/{client_id}", response_model=schemas.Client)
+def get_client(client_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Client).filter_by(id=client_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+
+@router.put("/{client_id}", response_model=schemas.Client)
+def update_client(
+    client_id: int,
+    client: schemas.Client,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    db_obj = db.query(models.Client).filter_by(id=client_id).first()
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    data = client.dict()
+    for k, v in data.items():
+        setattr(db_obj, k, v)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.delete("/{client_id}")
+def delete_client(
+    client_id: int,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    obj = db.query(models.Client).filter_by(id=client_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    obj.is_active = False
+    db.commit()
+    return {"ok": True}

--- a/backend/app/routes/digital_assets.py
+++ b/backend/app/routes/digital_assets.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, deps
+from .clients import require_service_manager
+
+router = APIRouter(prefix="/digitalassets", tags=["digitalassets"])
+
+
+@router.post("/", response_model=schemas.DigitalAsset)
+def create_digital_asset(
+    asset: schemas.DigitalAsset,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    client = db.query(models.Client).filter_by(id=asset.clientId, is_active=True).first()
+    if not client:
+        raise HTTPException(status_code=400, detail="Client not found or inactive")
+    db_obj = models.DigitalAsset(**asset.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=list[schemas.DigitalAsset])
+def list_digital_assets(db: Session = Depends(deps.get_db)):
+    return db.query(models.DigitalAsset).all()
+
+
+@router.get("/{asset_id}", response_model=schemas.DigitalAsset)
+def get_digital_asset(asset_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.DigitalAsset).filter_by(id=asset_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+
+@router.put("/{asset_id}", response_model=schemas.DigitalAsset)
+def update_digital_asset(
+    asset_id: int,
+    asset: schemas.DigitalAsset,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    db_obj = db.query(models.DigitalAsset).filter_by(id=asset_id).first()
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    client = db.query(models.Client).filter_by(id=asset.clientId, is_active=True).first()
+    if not client:
+        raise HTTPException(status_code=400, detail="Client not found or inactive")
+    data = asset.dict()
+    for k, v in data.items():
+        setattr(db_obj, k, v)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.delete("/{asset_id}")
+def delete_digital_asset(
+    asset_id: int,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    obj = db.query(models.DigitalAsset).filter_by(id=asset_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -1,0 +1,142 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, deps
+from .clients import require_service_manager
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+MAX_DEDICATION_HOURS = 40
+
+
+@router.post("/", response_model=schemas.Project)
+def create_project(
+    project: schemas.Project,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    asset = db.query(models.DigitalAsset).filter_by(id=project.digitalAssetsId).first()
+    if not asset:
+        raise HTTPException(status_code=400, detail="Digital asset not found")
+    client = db.query(models.Client).filter_by(id=asset.clientId, is_active=True).first()
+    if not client:
+        raise HTTPException(status_code=400, detail="Client inactive")
+    db_obj = models.Project(**project.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=list[schemas.Project])
+def list_projects(
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    if current_user.role.name in ["Analista de Pruebas con skill de automatización", "Automatizador de Pruebas"]:
+        projs = (
+            db.query(models.Project)
+            .join(models.ProjectEmployee, models.Project.id == models.ProjectEmployee.projectId)
+            .filter(models.ProjectEmployee.userId == current_user.id)
+            .all()
+        )
+        return projs
+    return db.query(models.Project).all()
+
+
+@router.get("/{project_id}", response_model=schemas.Project)
+def get_project(project_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Project).filter_by(id=project_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+
+@router.put("/{project_id}", response_model=schemas.Project)
+def update_project(
+    project_id: int,
+    project: schemas.Project,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    db_obj = db.query(models.Project).filter_by(id=project_id).first()
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    asset = db.query(models.DigitalAsset).filter_by(id=project.digitalAssetsId).first()
+    if not asset:
+        raise HTTPException(status_code=400, detail="Digital asset not found")
+    client = db.query(models.Client).filter_by(id=asset.clientId, is_active=True).first()
+    if not client:
+        raise HTTPException(status_code=400, detail="Client inactive")
+    data = project.dict()
+    for k, v in data.items():
+        setattr(db_obj, k, v)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.delete("/{project_id}")
+def delete_project(
+    project_id: int,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    obj = db.query(models.Project).filter_by(id=project_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    obj.is_active = False
+    db.commit()
+    return {"ok": True}
+
+
+@router.post("/{project_id}/analysts/{user_id}")
+def assign_analyst(
+    project_id: int,
+    user_id: int,
+    data: schemas.ProjectEmployee,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    project = db.query(models.Project).filter_by(id=project_id).first()
+    user = db.query(models.User).filter_by(id=user_id, is_active=True).first()
+    if not project or not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    current_hours = (
+        db.query(models.ProjectEmployee)
+        .filter(models.ProjectEmployee.userId == user_id)
+        .with_entities(models.ProjectEmployee.dedicationHours)
+        .all()
+    )
+    total = sum(h[0] or 0 for h in current_hours) + (data.dedicationHours or 0)
+    if total > MAX_DEDICATION_HOURS:
+        raise HTTPException(status_code=400, detail="Dedication exceeded")
+    db_obj = models.ProjectEmployee(
+        projectId=project_id,
+        userId=user_id,
+        objective=data.objective,
+        dedicationHours=data.dedicationHours,
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.delete("/{project_id}/analysts/{user_id}")
+def remove_analyst(
+    project_id: int,
+    user_id: int,
+    db: Session = Depends(deps.get_db),
+    _: models.User = Depends(require_service_manager),
+):
+    obj = (
+        db.query(models.ProjectEmployee)
+        .filter_by(projectId=project_id, userId=user_id)
+        .first()
+    )
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- create dedicated CRUD routers for clients, digital assets and projects
- enforce service manager permissions and required fields
- validate relations when creating/updating
- add project analyst assignment with dedication control
- register new routers in main FastAPI app

## Testing
- `pytest -q tests/test_current_user.py`
- `pytest -q` *(fails: AuditEvent/DataPool etc. not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_686539ad1f58832fba079230d164eb2e