### PR TITLE
Implement daily hours check

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,7 +1,8 @@
 import logging
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import Type, List
+from sqlalchemy import func
+from typing import Type, List, Optional
 
 from . import models, deps, crypto
 
@@ -15,6 +16,17 @@ def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
     def perm(method: str):
         return Depends(deps.require_api_permission(f"/{prefix}", method))
 
+    def _validate_dedication(user_id: int, hours: int, db: Session, exclude_id: Optional[int] = None) -> None:
+        """Ensure a user is not assigned more than 9 hours across projects."""
+        if user_id is None or hours is None:
+            return
+        q = db.query(func.sum(models.ProjectEmployee.dedicationHours)).filter(models.ProjectEmployee.userId == user_id)
+        if exclude_id is not None:
+            q = q.filter(models.ProjectEmployee.id != exclude_id)
+        total = q.scalar() or 0
+        if total + hours > 9:
+            raise HTTPException(status_code=400, detail="dedication hours exceed daily limit of 9")
+
     @router.post("/", response_model=schema, dependencies=[perm("POST")])
     def create(item: schema, db: Session = Depends(deps.get_db)):
         data = item.dict()
@@ -22,6 +34,12 @@ def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
             data["password"] = deps.get_password_hash(data["password"])
         if model is models.RawData and data.get("fieldValue") is not None:
             data["fieldValue"] = crypto.encrypt(data["fieldValue"])
+        if model is models.ProjectEmployee:
+            _validate_dedication(
+                data.get("userId"),
+                data.get("dedicationHours") or 0,
+                db,
+            )
         logger.debug("Creating %s with data: %s", model.__name__, data)
         db_obj = model(**data)
         db.add(db_obj)
@@ -59,6 +77,13 @@ def create_crud_router(prefix: str, model: Type[models.Base], schema: Type):
             data["password"] = deps.get_password_hash(data["password"])
         if model is models.RawData and "fieldValue" in data and data["fieldValue"] is not None:
             data["fieldValue"] = crypto.encrypt(data["fieldValue"])
+        if model is models.ProjectEmployee:
+            _validate_dedication(
+                data.get("userId", db_obj.userId),
+                data.get("dedicationHours", db_obj.dedicationHours) or 0,
+                db,
+                exclude_id=item_id,
+            )
         for field, value in data.items():
             setattr(db_obj, field, value)
         logger.debug("Updating %s %s with data: %s", model.__name__, item_id, data)

--- a/tests/test_projectemployee_dedication.py
+++ b/tests/test_projectemployee_dedication.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid import uuid4
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app import models, deps
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def _login() -> str:
+    resp = client.post("/token", data={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def _setup_projects() -> tuple[int, int, int]:
+    """Create a user and two projects sharing a digital asset."""
+    db: Session = SessionLocal()
+    client_obj = models.Client(name="c")
+    db.add(client_obj)
+    db.commit()
+    db.refresh(client_obj)
+
+    asset = models.DigitalAsset(clientId=client_obj.id)
+    db.add(asset)
+    db.commit()
+    db.refresh(asset)
+
+    project1 = models.Project(name="p1", digitalAssetsId=asset.id)
+    project2 = models.Project(name="p2", digitalAssetsId=asset.id)
+    db.add(project1)
+    db.add(project2)
+    db.commit()
+    db.refresh(project1)
+    db.refresh(project2)
+
+    user = models.User(
+        username=f"temp_{uuid4().hex[:6]}",
+        password=deps.get_password_hash("pwd"),
+        role_id=1,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    user_id = user.id
+    p1_id = project1.id
+    p2_id = project2.id
+    db.close()
+    return user_id, p1_id, p2_id
+
+
+def test_cannot_exceed_nine_hours():
+    token = _login()
+    user_id, p1, p2 = _setup_projects()
+
+    resp = client.post(
+        "/projectemployees/",
+        json={"id": 1, "projectId": p1, "userId": user_id, "objective": "", "dedicationHours": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/projectemployees/",
+        json={"id": 2, "projectId": p2, "userId": user_id, "objective": "", "dedicationHours": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert "dedication" in resp.json()["detail"]
+
+
+def test_update_respects_limit():
+    token = _login()
+    user_id, p1, p2 = _setup_projects()
+
+    resp = client.post(
+        "/projectemployees/",
+        json={"id": 3, "projectId": p1, "userId": user_id, "objective": "", "dedicationHours": 4},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assignment_id = resp.json()["id"]
+
+    resp = client.post(
+        "/projectemployees/",
+        json={"id": 4, "projectId": p2, "userId": user_id, "objective": "", "dedicationHours": 4},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.put(
+        f"/projectemployees/{assignment_id}",
+        json={"id": assignment_id, "projectId": p1, "userId": user_id, "objective": "", "dedicationHours": 6},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert "dedication" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- enforce 9-hour limit when creating or updating `ProjectEmployee`
- add tests verifying dedication hour validation

## Testing
- `pytest -q tests/test_projectemployee_dedication.py`

------
https://chatgpt.com/codex/tasks/task_e_68653a183650832fad15652c45d502f6