### PR TITLE
Improve service manager UI

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -68,6 +68,11 @@ export const routes: Routes = [
         canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
       },
       {
+        path: 'service-manager',
+        loadComponent: () => import('./components/service-manager/service-manager.component').then(m => m.ServiceManagerComponent),
+        canActivate: [() => import('./service-manager.guard').then(m => m.managerGuard)]
+      },
+      {
         path: 'interactions',
         loadComponent: () => import('./components/interactions/interactions.component').then(m => m.InteractionsComponent)
       }

--- a/frontend/src/app/components/client-admin/client-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/client-analysts.component.ts
@@ -96,8 +96,13 @@ export class ClientAnalystsComponent implements OnChanges {
 
   toggle(user: User, checked: boolean) {
     if (!this.client) return;
+    const dedication = this.dedication[user.id] ?? 100;
+    if (checked && (dedication < 1 || dedication > 100)) {
+      alert('La dedicaci\u00f3n debe estar entre 1 y 100');
+      return;
+    }
     const obs = checked
-      ? this.clientService.assignAnalyst(this.client.id, user.id, this.dedication[user.id] || 100)
+      ? this.clientService.assignAnalyst(this.client.id, user.id, dedication)
       : this.clientService.unassignAnalyst(this.client.id, user.id);
     obs.subscribe(c => {
       this.client = c;

--- a/frontend/src/app/components/client-admin/client-projects.component.ts
+++ b/frontend/src/app/components/client-admin/client-projects.component.ts
@@ -77,6 +77,14 @@ export class ClientProjectsComponent implements OnChanges {
   }
 
   save() {
+    if (!this.form.name.trim()) {
+      alert('El nombre es obligatorio');
+      return;
+    }
+    if (!this.client?.is_active) {
+      alert('Cliente inactivo');
+      return;
+    }
     const obs = this.editing
       ? this.projectService.updateProject(this.editing.id, this.form)
       : this.projectService.createProject(this.form);

--- a/frontend/src/app/components/client-admin/project-analysts.component.ts
+++ b/frontend/src/app/components/client-admin/project-analysts.component.ts
@@ -101,8 +101,13 @@ export class ProjectAnalystsComponent implements OnChanges {
     if (!confirm(msg)) {
       return;
     }
+    const scripts = this.scripts[user.id] ?? 0;
+    if (checked && scripts <= 0) {
+      alert('Indique scripts por d\u00eda mayores a 0');
+      return;
+    }
     const obs = checked ?
-      this.projectService.assignAnalyst(this.project.id, user.id, this.scripts[user.id] || 0) :
+      this.projectService.assignAnalyst(this.project.id, user.id, scripts) :
       this.projectService.unassignAnalyst(this.project.id, user.id);
     obs.subscribe(p => {
       this.project = p;

--- a/frontend/src/app/components/service-manager/service-manager.component.ts
+++ b/frontend/src/app/components/service-manager/service-manager.component.ts
@@ -114,15 +114,31 @@ export class ServiceManagerComponent implements OnInit {
   createClient() {
     const name = this.newClient.trim();
     if (!name) return;
-    this.clientService.createClient({name}).subscribe(() => {
-      this.newClient='';
-      this.loadData();
+    this.clientService.createClient({name}).subscribe({
+      next: () => {
+        this.newClient='';
+        this.loadData();
+        alert('Cliente creado');
+      },
+      error: err => {
+        console.error('Error creating client:', err);
+        alert('Error al crear cliente');
+      }
     });
   }
 
-  openClientAnalysts(c: Client) { this.selectedClient = c; }
-  openProjectAnalysts(p: Project) { this.selectedProject = p; }
-  openProjects(c: Client) { this.projectClient = c; }
+  openClientAnalysts(c: Client) {
+    if (!c.is_active) { alert('Cliente inactivo'); return; }
+    this.selectedClient = c;
+  }
+  openProjectAnalysts(p: Project) {
+    if (!p.is_active) { alert('Proyecto inactivo'); return; }
+    this.selectedProject = p;
+  }
+  openProjects(c: Client) {
+    if (!c.is_active) { alert('Cliente inactivo'); return; }
+    this.projectClient = c;
+  }
 
   filteredProjects(): Project[] {
     return this.filterClient ? this.projects.filter(p => p.client_id === this.filterClient) : this.projects;

--- a/frontend/src/app/service-manager.guard.ts
+++ b/frontend/src/app/service-manager.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+import { of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export const managerGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+
+  if (!api.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  return api.getCurrentUser().pipe(
+    map(user =>
+      user.role?.name === 'Gerente de servicios'
+        ? true
+        : router.createUrlTree(['/dashboard'])
+    ),
+    catchError(() => of(router.createUrlTree(['/dashboard'])))
+  );
+};


### PR DESCRIPTION
## Summary
- add a route guard restricting access to Service Manager
- register Service Manager route using new guard
- validate dedication and scripts per day before assignments
- validate project creation form and client status
- show alerts on create client and prevent actions on inactive records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653a838f00832f8bc044bfaa38a491