### PR TITLE
Improve JWT handling on frontend

### DIFF
--- a/frontend/src/app/components/login/login-v2.component.ts
+++ b/frontend/src/app/components/login/login-v2.component.ts
@@ -308,8 +308,14 @@ export class LoginComponent implements OnInit {
 
     this.authService.login(this.loginForm.value).subscribe({
       next: (response) => {
-        // Login exitoso, redirigir a selección de workspace
-        this.router.navigate(['/workspace']);
+        this.authService.getCurrentUser().subscribe({
+          next: () => {
+            this.router.navigate(['/workspace']);
+          },
+          error: () => {
+            this.router.navigate(['/workspace']);
+          }
+        });
       },
       error: (error) => {
         this.loading = false;

--- a/frontend/src/app/jwt.interceptor.ts
+++ b/frontend/src/app/jwt.interceptor.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = localStorage.getItem('token');
+    if (token) {
+      const authReq = req.clone({
+        setHeaders: { Authorization: `Bearer ${token}` }
+      });
+      return next.handle(authReq);
+    }
+    return next.handle(req);
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -28,18 +28,17 @@ export interface UserInfo {
 export interface AuthResponse {
   access_token: string;
   token_type: string;
-  user: UserInfo;
 }
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  private baseUrl = 'http://localhost:8000/api/auth';
+  private baseUrl = 'http://localhost:8000';
   private currentUserSubject = new BehaviorSubject<UserInfo | null>(null);
   public currentUser$ = this.currentUserSubject.asObservable();
   
-  private tokenKey = 'access_token';
+  private tokenKey = 'token';
   private userKey = 'current_user';
 
   constructor(
@@ -84,13 +83,10 @@ export class AuthService {
     formData.append('username', credentials.username);
     formData.append('password', credentials.password);
     
-    return this.http.post<AuthResponse>(`${this.baseUrl}/login`, formData)
+    return this.http.post<AuthResponse>(`${this.baseUrl}/token`, formData)
       .pipe(
         tap(response => {
-          // Guardar token y usuario
           localStorage.setItem(this.tokenKey, response.access_token);
-          localStorage.setItem(this.userKey, JSON.stringify(response.user));
-          this.currentUserSubject.next(response.user);
         }),
         catchError(error => {
           let message = 'Error al iniciar sesión';
@@ -125,7 +121,7 @@ export class AuthService {
   }
 
   getCurrentUser(): Observable<UserInfo> {
-    return this.http.get<UserInfo>(`${this.baseUrl}/me`, { headers: this.getHeaders() })
+    return this.http.get<UserInfo>(`${this.baseUrl}/users/me/`, { headers: this.getHeaders() })
       .pipe(
         tap(user => {
           localStorage.setItem(this.userKey, JSON.stringify(user));

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,6 +7,7 @@ import { RouterModule } from '@angular/router';
 import { routes } from './app/app.routes';
 import { WorkspaceInterceptor } from './app/workspace.interceptor';
 import { AuthInterceptor } from './app/auth.interceptor';
+import { JwtInterceptor } from './app/jwt.interceptor';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -18,6 +19,11 @@ bootstrapApplication(AppComponent, {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: WorkspaceInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: JwtInterceptor,
       multi: true
     },
     {


### PR DESCRIPTION
## Summary
- add JwtInterceptor to attach Authorization headers
- register interceptor in app bootstrap
- update AuthService to work with `/token` endpoint and store token consistently
- update Login V2 component to load user info after login

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError: module 'backend.app.models' has no attribute 'AuditEvent', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68653a35e038832fb38f638dd9f697d0