### PR TITLE
Improve admin user management

### DIFF
--- a/frontend/src/app/components/users/user-form.component.ts
+++ b/frontend/src/app/components/users/user-form.component.ts
@@ -1,0 +1,94 @@
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { User, UserCreate, Role } from '../../models';
+import { UserService } from '../../services/user.service';
+import { RoleService } from '../../services/role.service';
+
+@Component({
+  selector: 'app-user-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">{{ user ? 'Editar Usuario' : 'Nuevo Usuario' }}</h3>
+        <form (ngSubmit)="save()">
+          <div class="mb-3">
+            <label class="form-label">Usuario</label>
+            <input class="form-control" [(ngModel)]="form.username" name="username" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Contraseña</label>
+            <input type="password" class="form-control" [(ngModel)]="form.password" name="password" [required]="!user" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Rol</label>
+            <select class="form-select" [(ngModel)]="form.role_id" name="role_id" required>
+              <option *ngFor="let r of roles" [ngValue]="r.id">{{ r.name }}</option>
+            </select>
+          </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="active" [(ngModel)]="form.is_active" name="is_active" />
+            <label class="form-check-label" for="active">Activo</label>
+          </div>
+          <div *ngIf="error" class="alert alert-danger">{{ error }}</div>
+          <button class="btn btn-primary" type="submit" [disabled]="saving">Guardar</button>
+          <button type="button" class="btn btn-secondary ms-2" (click)="cancel.emit()" [disabled]="saving">Cancelar</button>
+        </form>
+      </div>
+    </div>
+  `
+})
+export class UserFormComponent implements OnInit {
+  @Input() user: User | null = null;
+  @Output() saved = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  roles: Role[] = [];
+  saving = false;
+  error = '';
+
+  form: any = {
+    username: '',
+    password: '',
+    role_id: null,
+    is_active: true
+  };
+
+  constructor(private userService: UserService, private roleService: RoleService) {}
+
+  ngOnInit() {
+    this.roleService.getRoles().subscribe(rs => (this.roles = rs));
+    if (this.user) {
+      this.form = {
+        username: this.user.username,
+        password: '',
+        role_id: this.user.role.id,
+        is_active: this.user.is_active
+      };
+    }
+  }
+
+  save() {
+    if (!this.form.username || (!this.user && !this.form.password) || !this.form.role_id) {
+      this.error = 'Todos los campos son obligatorios';
+      return;
+    }
+    this.saving = true;
+    this.error = '';
+    const obs = this.user
+      ? this.userService.updateUser(this.user.id, this.form)
+      : this.userService.createUser(this.form as UserCreate & { role_id: number; is_active: boolean });
+    obs.subscribe({
+      next: () => {
+        this.saving = false;
+        this.saved.emit();
+      },
+      error: (err) => {
+        this.saving = false;
+        this.error = err.error?.detail || 'Error al guardar';
+      }
+    });
+  }
+}

--- a/frontend/src/app/components/users/users.component.ts
+++ b/frontend/src/app/components/users/users.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { UserFormComponent } from './user-form.component';
 import { User, Role } from '../../models';
 import { UserService } from '../../services/user.service';
 import { RoleService } from '../../services/role.service';
@@ -10,14 +11,14 @@ import { ApiService } from '../../services/api.service';
 @Component({
   selector: 'app-users',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule],
+  imports: [CommonModule, FormsModule, RouterModule, UserFormComponent],
   template: `
     <div class="main-panel">
       <h1>Usuarios</h1>
-      <button class="btn btn-primary mb-2" routerLink="/register">Registrar Usuario</button>
+      <button class="btn btn-primary mb-2" (click)="new()">Nuevo Usuario</button>
       <table class="table" *ngIf="users.length > 0">
         <thead>
-          <tr><th>Username</th><th>Rol</th><th>Último Login</th><th>Activo</th></tr>
+          <tr><th>Usuario</th><th>Rol</th><th>Último Login</th><th>Activo</th><th></th></tr>
         </thead>
         <tbody>
           <tr *ngFor="let u of users">
@@ -34,10 +35,19 @@ import { ApiService } from '../../services/api.service';
                      (change)="toggleActive(u, $event)"
                      [disabled]="u.id === currentUserId" />
             </td>
+            <td>
+              <button class="btn btn-sm btn-secondary me-2" (click)="edit(u)">Editar</button>
+              <button class="btn btn-sm btn-danger" (click)="remove(u)" [disabled]="u.id === currentUserId">Eliminar</button>
+            </td>
           </tr>
         </tbody>
       </table>
       <div *ngIf="users.length === 0">No hay usuarios.</div>
+
+      <app-user-form *ngIf="showForm" [user]="editing" (saved)="onSaved()" (cancel)="showForm=false"></app-user-form>
+
+      <div *ngIf="message" class="alert alert-info mt-2">{{ message }}</div>
+      <div *ngIf="error" class="alert alert-danger mt-2">{{ error }}</div>
     </div>
   `
 })
@@ -45,6 +55,10 @@ export class UsersComponent implements OnInit {
   users: User[] = [];
   roles: Role[] = [];
   currentUser: User | null = null;
+  showForm = false;
+  editing: User | null = null;
+  message = '';
+  error = '';
 
   constructor(
     private userService: UserService,
@@ -64,14 +78,40 @@ export class UsersComponent implements OnInit {
     this.userService.getUsers().subscribe(us => this.users = us);
   }
 
+  new() { this.editing = null; this.showForm = true; }
+
+  edit(u: User) { this.editing = u; this.showForm = true; }
+
+  remove(u: User) {
+    if (confirm('¿Eliminar usuario?')) {
+      this.userService.deleteUser(u.id).subscribe({
+        next: () => { this.message = 'Usuario eliminado'; this.load(); },
+        error: err => { this.error = err.error?.detail || 'Error al eliminar'; }
+      });
+    }
+  }
+
   changeRole(user: User) {
-    this.userService.updateUserRole(user.id, { role_id: user.role.id }).subscribe();
+    this.userService.updateUserRole(user.id, { role_id: user.role.id }).subscribe({
+      next: () => this.message = 'Rol actualizado',
+      error: err => this.error = err.error?.detail || 'Error al actualizar rol'
+    });
   }
 
   toggleActive(user: User, event?: Event) {
     const checked = event ? (event.target as HTMLInputElement).checked : !user.is_active;
     this.userService.updateUserActive(user.id, checked)
-      .subscribe(u => user.is_active = u.is_active);
+      .subscribe({
+        next: u => { user.is_active = u.is_active; this.message = 'Estado actualizado'; },
+        error: err => this.error = err.error?.detail || 'Error al actualizar estado'
+      });
+  }
+
+  onSaved() {
+    this.showForm = false;
+    this.load();
+    this.message = this.editing ? 'Usuario actualizado' : 'Usuario creado';
+    this.editing = null;
   }
 
   get currentUserId(): number | null {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -103,6 +103,14 @@ export class ApiService {
     return this.http.put<User>(`${this.baseUrl}/users/${userId}/active`, { is_active: isActive }, { headers: this.getHeaders() });
   }
 
+  updateUser(id: number, data: any): Observable<User> {
+    return this.http.put<User>(`${this.baseUrl}/users/${id}`, data, { headers: this.getHeaders() });
+  }
+
+  deleteUser(id: number): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/users/${id}`, { headers: this.getHeaders() });
+  }
+
   getUsers(): Observable<User[]> {
     return this.http.get<User[]>(`${this.baseUrl}/users/`, { headers: this.getHeaders() });
   }

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -19,6 +19,14 @@ export class UserService {
     return this.api.createUser(user);
   }
 
+  updateUser(id: number, data: any): Observable<User> {
+    return this.api.updateUser(id, data);
+  }
+
+  deleteUser(id: number): Observable<any> {
+    return this.api.deleteUser(id);
+  }
+
   updateUserRole(id: number, role: UserRoleUpdate): Observable<User> {
     return this.api.updateUserRole(id, role);
   }


### PR DESCRIPTION
## Summary
- add user form for admin CRUD
- support user update and removal in services
- refresh listing and show messages after actions

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653a4929f4832faf639159869c4782