### PR TITLE
Add digital asset selection and analyst guard

### DIFF
--- a/frontend/src/app/analyst.guard.ts
+++ b/frontend/src/app/analyst.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+import { of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export const analystGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+
+  if (!api.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  return api.getCurrentUser().pipe(
+    map(user => {
+      const role = user.role?.name;
+      return role === 'Analista de pruebas' || role === 'Automatizador'
+        ? true
+        : router.createUrlTree(['/']);
+    }),
+    catchError(() => of(router.createUrlTree(['/'])))
+  );
+};

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -24,20 +24,27 @@ export const routes: Routes = [
         loadComponent: () => import('./components/actors/actors.component').then(m => m.ActorsComponent)
       },
       {
+        path: 'clients/:clientId/assets',
+        loadComponent: () => import('./components/digital-assets/digital-assets.component').then(m => m.DigitalAssetsComponent)
+      },
+      {
         path: 'clients/:clientId/projects',
         loadComponent: () => import('./components/projects/projects.component').then(m => m.ProjectsComponent)
       },
       {
         path: 'projects/:projectId/scenarios',
-        loadComponent: () => import('./components/scenarios/scenarios.component').then(m => m.ScenariosComponent)
+        loadComponent: () => import('./components/scenarios/scenarios.component').then(m => m.ScenariosComponent),
+        canActivate: [() => import('./analyst.guard').then(m => m.analystGuard)]
       },
       {
         path: 'projects/:projectId/scenarios/:scenarioId/tasks',
-        loadComponent: () => import('./components/tasks/tasks.component').then(m => m.TasksComponent)
+        loadComponent: () => import('./components/tasks/tasks.component').then(m => m.TasksComponent),
+        canActivate: [() => import('./analyst.guard').then(m => m.analystGuard)]
       },
       {
         path: 'projects/:projectId/scenarios/:scenarioId/data',
-        loadComponent: () => import('./components/scenario-data/scenario-data.component').then(m => m.ScenarioDataComponent)
+        loadComponent: () => import('./components/scenario-data/scenario-data.component').then(m => m.ScenarioDataComponent),
+        canActivate: [() => import('./analyst.guard').then(m => m.analystGuard)]
       },
       {
         path: 'projects/:projectId/features',

--- a/frontend/src/app/components/digital-assets/digital-assets.component.ts
+++ b/frontend/src/app/components/digital-assets/digital-assets.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DigitalAsset, Client, DigitalAssetCreate } from '../../models';
+import { DigitalAssetService } from '../../services/digital-asset.service';
+import { ClientService } from '../../services/client.service';
+
+@Component({
+  selector: 'app-digital-assets',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="main-panel">
+      <h1>Activos Digitales</h1>
+      <div class="d-flex gap-2 mb-3">
+        <select class="form-control" [(ngModel)]="clientId" (change)="load()">
+          <option [ngValue]="null">Cliente</option>
+          <option *ngFor="let c of clients" [ngValue]="c.id">{{ c.name }}</option>
+        </select>
+        <input class="form-control" [(ngModel)]="form.description" placeholder="Descripción">
+        <button class="btn btn-primary" (click)="save()">Agregar</button>
+      </div>
+      <table class="table table-bordered" *ngIf="assets.length > 0">
+        <thead>
+          <tr><th>Descripción</th><th>Cliente</th><th></th></tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let a of assets">
+            <td>{{ a.description }}</td>
+            <td>{{ clientName(a.clientId) }}</td>
+            <td><button class="btn btn-sm btn-danger" (click)="remove(a)">Eliminar</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <div *ngIf="assets.length === 0">No hay activos.</div>
+    </div>
+  `,
+  styles: [`
+    .gap-2 { gap: .5rem; }
+  `]
+})
+export class DigitalAssetsComponent implements OnInit {
+  clients: Client[] = [];
+  assets: DigitalAsset[] = [];
+  clientId: number | null = null;
+  form: DigitalAssetCreate = { clientId: 0, description: '' };
+
+  constructor(private assetService: DigitalAssetService, private clientService: ClientService) {}
+
+  ngOnInit() {
+    this.clientService.getClients().subscribe(c => this.clients = c);
+    this.load();
+  }
+
+  load() {
+    this.assetService.getAssets(this.clientId || undefined).subscribe(a => this.assets = a);
+    if (this.clientId !== null) {
+      this.form.clientId = this.clientId;
+    }
+  }
+
+  clientName(id: number) {
+    return this.clients.find(c => c.id === id)?.name || '-';
+  }
+
+  save() {
+    if (!this.form.clientId || !this.form.description) return;
+    this.assetService.createAsset(this.form).subscribe(() => {
+      this.form.description = '';
+      this.load();
+    });
+  }
+
+  remove(a: DigitalAsset) {
+    if (confirm('¿Eliminar activo digital?')) {
+      this.assetService.deleteAsset(a.id).subscribe(() => this.load());
+    }
+  }
+}

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -24,6 +24,7 @@ export interface Project {
   id: number;
   name: string;
   client_id: number;
+  digitalAssetsId: number;
   is_active: boolean;
   analysts: User[];
   objetivo?: string;
@@ -358,4 +359,42 @@ export interface Feature {
   name: string;
   description: string;
   status: boolean;
+}
+
+export interface DigitalAsset {
+  id: number;
+  clientId: number;
+  description: string;
+  okr?: string;
+  kpi?: string;
+}
+
+export interface DigitalAssetCreate {
+  clientId: number;
+  description: string;
+  okr?: string;
+  kpi?: string;
+}
+
+export interface Scenario {
+  id: number;
+  name: string;
+  description?: string;
+  status: boolean;
+}
+
+export interface ScenarioCreate {
+  name: string;
+  description?: string;
+}
+
+export interface ScenarioData {
+  id: number;
+  idScenario: number;
+  status: boolean;
+}
+
+export interface ScenarioDataCreate {
+  idScenario: number;
+  status?: boolean;
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -12,6 +12,7 @@ import {
   LoginRequest, LoginResponse, UserRoleUpdate, PendingExecution,
   MarketplaceComponent, MarketplaceComponentCreate,
   Task, Interaction, Validation, Question, RawData, Feature,
+  DigitalAsset, DigitalAssetCreate,
   PagePermission, PagePermissionCreate, ApiPermission, ApiPermissionCreate
 } from '../models';
 
@@ -154,6 +155,24 @@ export class ApiService {
 
   unassignClientAnalyst(clientId: number, userId: number): Observable<Client> {
     return this.http.delete<Client>(`${this.baseUrl}/clients/${clientId}/analysts/${userId}`, { headers: this.getHeaders() });
+  }
+
+  // Digital Assets
+  getDigitalAssets(clientId?: number): Observable<DigitalAsset[]> {
+    const query = clientId ? `?clientId=${clientId}` : '';
+    return this.http.get<DigitalAsset[]>(`${this.baseUrl}/digitalassets/${query}`, { headers: this.getHeaders() });
+  }
+
+  createDigitalAsset(asset: DigitalAssetCreate): Observable<DigitalAsset> {
+    return this.http.post<DigitalAsset>(`${this.baseUrl}/digitalassets/`, asset, { headers: this.getHeaders() });
+  }
+
+  updateDigitalAsset(id: number, asset: DigitalAssetCreate): Observable<DigitalAsset> {
+    return this.http.put<DigitalAsset>(`${this.baseUrl}/digitalassets/${id}`, asset, { headers: this.getHeaders() });
+  }
+
+  deleteDigitalAsset(id: number): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/digitalassets/${id}`, { headers: this.getHeaders() });
   }
 
   // Proyectos

--- a/frontend/src/app/services/digital-asset.service.ts
+++ b/frontend/src/app/services/digital-asset.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { DigitalAsset, DigitalAssetCreate } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class DigitalAssetService {
+  constructor(private api: ApiService) {}
+
+  getAssets(clientId?: number): Observable<DigitalAsset[]> {
+    return this.api.getDigitalAssets(clientId);
+  }
+
+  createAsset(asset: DigitalAssetCreate): Observable<DigitalAsset> {
+    return this.api.createDigitalAsset(asset);
+  }
+
+  updateAsset(id: number, asset: DigitalAssetCreate): Observable<DigitalAsset> {
+    return this.api.updateDigitalAsset(id, asset);
+  }
+
+  deleteAsset(id: number): Observable<any> {
+    return this.api.deleteDigitalAsset(id);
+  }
+}

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { ApiService } from './api.service';
 import { Project, ProjectCreate } from '../models';
 
@@ -17,6 +17,12 @@ export class ProjectService {
 
   getProjectsByClient(clientId: number): Observable<Project[]> {
     return this.api.getProjectsByClient(clientId);
+  }
+
+  getProjectsByAsset(assetId: number): Observable<Project[]> {
+    return this.api.getProjects().pipe(
+      map(ps => ps.filter(p => p.digitalAssetsId === assetId))
+    );
   }
 
   createProject(project: ProjectCreate): Observable<Project> {


### PR DESCRIPTION
## Summary
- extend models to support digital assets and scenarios
- add DigitalAsset API methods and service
- create DigitalAssetsComponent for CRUD of digital assets
- enhance Workspace selector to choose digital assets before projects
- add AnalystGuard to restrict analyst-only routes

## Testing
- `npx tsc -p tsconfig.app.json`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68653add201c832fb10ad8b3d1be28c1