### PR TITLE
Add interaction and validation routers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -200,35 +200,13 @@ def register_cruds():
         ("projectemployees", models.ProjectEmployee, schemas.ProjectEmployee),
         ("actors", models.Actor, schemas.Actor),
         ("habilities", models.Hability, schemas.Hability),
-        ("interactions", models.Interaction, schemas.Interaction),
-        (
-            "interactionparameters",
-            models.InteractionParameter,
-            schemas.InteractionParameter,
-        ),
-        (
-            "interactionapprovalstates",
-            models.InteractionApprovalState,
-            schemas.InteractionApprovalState,
-        ),
-        (
-            "interactionapprovals",
-            models.InteractionApproval,
-            schemas.InteractionApproval,
-        ),
+        ("interactionapprovalstates", models.InteractionApprovalState, schemas.InteractionApprovalState),
         ("tasks", models.Task, schemas.Task),
         (
             "taskhaveinteractions",
             models.TaskHaveInteraction,
             schemas.TaskHaveInteraction,
         ),
-        ("validations", models.Validation, schemas.Validation),
-        (
-            "validationparameters",
-            models.ValidationParameter,
-            schemas.ValidationParameter,
-        ),
-        ("validationapprovals", models.ValidationApproval, schemas.ValidationApproval),
         ("questions", models.Question, schemas.Question),
         (
             "questionhasvalidations",
@@ -250,6 +228,16 @@ def register_cruds():
 
 
 register_cruds()
+
+from .routes import interactions as interactions_routes
+from .routes import validations as validations_routes
+
+app.include_router(interactions_routes.router)
+app.include_router(interactions_routes.param_router)
+app.include_router(interactions_routes.approval_router)
+app.include_router(validations_routes.router)
+app.include_router(validations_routes.param_router)
+app.include_router(validations_routes.approval_router)
 
 
 @app.get("/users/me/", response_model=schemas.User)

--- a/backend/app/routes/interactions.py
+++ b/backend/app/routes/interactions.py
@@ -1,0 +1,145 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, deps
+
+router = APIRouter(prefix="/interactions", tags=["interactions"])
+
+perm = lambda method: Depends(deps.require_api_permission("/interactions", method))
+
+@router.post("/", response_model=schemas.Interaction, status_code=status.HTTP_201_CREATED, dependencies=[perm("POST")])
+def create_interaction(data: schemas.InteractionCreate, db: Session = Depends(deps.get_db)):
+    if db.query(models.Interaction).filter_by(code=data.code).first():
+        raise HTTPException(status_code=400, detail="Code exists")
+    obj = models.Interaction(**data.dict())
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@router.get("/", response_model=list[schemas.Interaction], dependencies=[perm("GET")])
+def list_interactions(db: Session = Depends(deps.get_db)):
+    return db.query(models.Interaction).all()
+
+@router.get("/{interaction_id}", response_model=schemas.Interaction, dependencies=[perm("GET")])
+def get_interaction(interaction_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Interaction).filter_by(id=interaction_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+@router.put("/{interaction_id}", response_model=schemas.Interaction, dependencies=[perm("PUT")])
+def update_interaction(interaction_id: int, data: schemas.InteractionUpdate, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Interaction).filter_by(id=interaction_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(obj, field, value)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@router.delete("/{interaction_id}", dependencies=[perm("DELETE")])
+def delete_interaction(interaction_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Interaction).filter_by(id=interaction_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}
+
+# ------------------ Parameters ------------------
+param_router = APIRouter(prefix="/interactionparameters", tags=["interactionparameters"])
+param_perm = lambda method: Depends(deps.require_api_permission("/interactionparameters", method))
+
+@param_router.post("/", response_model=schemas.InteractionParameter, status_code=status.HTTP_201_CREATED, dependencies=[param_perm("POST")])
+def create_parameter(data: schemas.InteractionParameterCreate, db: Session = Depends(deps.get_db)):
+    if not db.query(models.Interaction).filter_by(id=data.interactionId).first():
+        raise HTTPException(status_code=404, detail="Interaction not found")
+    obj = models.InteractionParameter(**data.dict())
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@param_router.get("/", response_model=list[schemas.InteractionParameter], dependencies=[param_perm("GET")])
+def list_parameters(db: Session = Depends(deps.get_db)):
+    return db.query(models.InteractionParameter).all()
+
+@param_router.get("/{parameter_id}", response_model=schemas.InteractionParameter, dependencies=[param_perm("GET")])
+def get_parameter(parameter_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.InteractionParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+@param_router.put("/{parameter_id}", response_model=schemas.InteractionParameter, dependencies=[param_perm("PUT")])
+def update_parameter(parameter_id: int, data: schemas.InteractionParameterUpdate, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.InteractionParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(obj, field, value)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@param_router.delete("/{parameter_id}", dependencies=[param_perm("DELETE")])
+def delete_parameter(parameter_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.InteractionParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}
+
+# ------------------ Approvals ------------------
+approval_router = APIRouter(prefix="/interactionapprovals", tags=["interactionapprovals"])
+approval_perm = lambda method: Depends(deps.require_api_permission("/interactionapprovals", method))
+
+@approval_router.post("/", response_model=schemas.InteractionApproval, status_code=status.HTTP_201_CREATED, dependencies=[approval_perm("POST")])
+def create_approval(data: schemas.InteractionApprovalCreate, db: Session = Depends(deps.get_db)):
+    interaction = db.query(models.Interaction).filter_by(id=data.interactionId).first()
+    if not interaction:
+        raise HTTPException(status_code=404, detail="Interaction not found")
+    state = db.query(models.InteractionApprovalState).filter_by(id=data.interactionAprovalStateId).first()
+    if not state:
+        raise HTTPException(status_code=400, detail="Invalid state")
+
+    approved = db.query(models.InteractionApprovalState).filter_by(name="aprobado").first()
+    rejected = db.query(models.InteractionApprovalState).filter_by(name="rechazado").first()
+    existing = (
+        db.query(models.InteractionApproval)
+        .filter(models.InteractionApproval.interactionId == data.interactionId)
+        .filter(models.InteractionApproval.interactionAprovalStateId.in_([approved.id, rejected.id]))
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Interaction already closed")
+
+    obj = models.InteractionApproval(
+        interactionId=data.interactionId,
+        creatorId=data.creatorId,
+        aprovalUserId=data.aprovalUserId,
+        comment=data.comment,
+        interactionAprovalStateId=data.interactionAprovalStateId,
+        creationDate=datetime.utcnow(),
+    )
+    if data.interactionAprovalStateId in [approved.id, rejected.id]:
+        obj.aprovalDate = datetime.utcnow()
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@approval_router.get("/", response_model=list[schemas.InteractionApproval], dependencies=[approval_perm("GET")])
+def list_approvals(db: Session = Depends(deps.get_db)):
+    return db.query(models.InteractionApproval).all()
+
+@approval_router.get("/{approval_id}", response_model=schemas.InteractionApproval, dependencies=[approval_perm("GET")])
+def get_approval(approval_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.InteractionApproval).filter_by(id=approval_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj

--- a/backend/app/routes/validations.py
+++ b/backend/app/routes/validations.py
@@ -1,0 +1,144 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, deps
+
+router = APIRouter(prefix="/validations", tags=["validations"])
+perm = lambda method: Depends(deps.require_api_permission("/validations", method))
+
+@router.post("/", response_model=schemas.Validation, status_code=status.HTTP_201_CREATED, dependencies=[perm("POST")])
+def create_validation(data: schemas.ValidationCreate, db: Session = Depends(deps.get_db)):
+    if db.query(models.Validation).filter_by(code=data.code).first():
+        raise HTTPException(status_code=400, detail="Code exists")
+    obj = models.Validation(**data.dict())
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@router.get("/", response_model=list[schemas.Validation], dependencies=[perm("GET")])
+def list_validations(db: Session = Depends(deps.get_db)):
+    return db.query(models.Validation).all()
+
+@router.get("/{validation_id}", response_model=schemas.Validation, dependencies=[perm("GET")])
+def get_validation(validation_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Validation).filter_by(id=validation_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+@router.put("/{validation_id}", response_model=schemas.Validation, dependencies=[perm("PUT")])
+def update_validation(validation_id: int, data: schemas.ValidationUpdate, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Validation).filter_by(id=validation_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(obj, field, value)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@router.delete("/{validation_id}", dependencies=[perm("DELETE")])
+def delete_validation(validation_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.Validation).filter_by(id=validation_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}
+
+# ------------------ Parameters ------------------
+param_router = APIRouter(prefix="/validationparameters", tags=["validationparameters"])
+param_perm = lambda method: Depends(deps.require_api_permission("/validationparameters", method))
+
+@param_router.post("/", response_model=schemas.ValidationParameter, status_code=status.HTTP_201_CREATED, dependencies=[param_perm("POST")])
+def create_val_parameter(data: schemas.ValidationParameterCreate, db: Session = Depends(deps.get_db)):
+    if not db.query(models.Validation).filter_by(id=data.interactionId).first():
+        raise HTTPException(status_code=404, detail="Validation not found")
+    obj = models.ValidationParameter(**data.dict())
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@param_router.get("/", response_model=list[schemas.ValidationParameter], dependencies=[param_perm("GET")])
+def list_val_parameters(db: Session = Depends(deps.get_db)):
+    return db.query(models.ValidationParameter).all()
+
+@param_router.get("/{parameter_id}", response_model=schemas.ValidationParameter, dependencies=[param_perm("GET")])
+def get_val_parameter(parameter_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.ValidationParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj
+
+@param_router.put("/{parameter_id}", response_model=schemas.ValidationParameter, dependencies=[param_perm("PUT")])
+def update_val_parameter(parameter_id: int, data: schemas.ValidationParameterUpdate, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.ValidationParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(obj, field, value)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@param_router.delete("/{parameter_id}", dependencies=[param_perm("DELETE")])
+def delete_val_parameter(parameter_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.ValidationParameter).filter_by(id=parameter_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}
+
+# ------------------ Approvals ------------------
+approval_router = APIRouter(prefix="/validationapprovals", tags=["validationapprovals"])
+approval_perm = lambda method: Depends(deps.require_api_permission("/validationapprovals", method))
+
+@approval_router.post("/", response_model=schemas.ValidationApproval, status_code=status.HTTP_201_CREATED, dependencies=[approval_perm("POST")])
+def create_val_approval(data: schemas.ValidationApprovalCreate, db: Session = Depends(deps.get_db)):
+    validation = db.query(models.Validation).filter_by(id=data.validationId).first()
+    if not validation:
+        raise HTTPException(status_code=404, detail="Validation not found")
+    state = db.query(models.InteractionApprovalState).filter_by(id=data.interactionAprovalStateId).first()
+    if not state:
+        raise HTTPException(status_code=400, detail="Invalid state")
+
+    approved = db.query(models.InteractionApprovalState).filter_by(name="aprobado").first()
+    rejected = db.query(models.InteractionApprovalState).filter_by(name="rechazado").first()
+    existing = (
+        db.query(models.ValidationApproval)
+        .filter(models.ValidationApproval.validationId == data.validationId)
+        .filter(models.ValidationApproval.interactionAprovalStateId.in_([approved.id, rejected.id]))
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Validation already closed")
+
+    obj = models.ValidationApproval(
+        validationId=data.validationId,
+        creatorId=data.creatorId,
+        aprovalUserId=data.aprovalUserId,
+        comment=data.comment,
+        interactionAprovalStateId=data.interactionAprovalStateId,
+        creationDate=datetime.utcnow(),
+    )
+    if data.interactionAprovalStateId in [approved.id, rejected.id]:
+        obj.aprovalDate = datetime.utcnow()
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+@approval_router.get("/", response_model=list[schemas.ValidationApproval], dependencies=[approval_perm("GET")])
+def list_val_approvals(db: Session = Depends(deps.get_db)):
+    return db.query(models.ValidationApproval).all()
+
+@approval_router.get("/{approval_id}", response_model=schemas.ValidationApproval, dependencies=[approval_perm("GET")])
+def get_val_approval(approval_id: int, db: Session = Depends(deps.get_db)):
+    obj = db.query(models.ValidationApproval).filter_by(id=approval_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Not found")
+    return obj

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -235,6 +235,48 @@ class InteractionApproval(BaseModel):
         orm_mode = True
 
 
+class InteractionCreate(BaseModel):
+    userId: int
+    code: str
+    name: str
+    requireReview: bool = False
+    description: str
+
+
+class InteractionUpdate(BaseModel):
+    code: Optional[str] = None
+    name: Optional[str] = None
+    requireReview: Optional[bool] = None
+    description: Optional[str] = None
+
+
+class InteractionParameterCreate(BaseModel):
+    interactionId: int
+    name: str
+    description: str
+    direction: bool = True
+
+
+class InteractionParameterUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    direction: Optional[bool] = None
+
+
+class InteractionApprovalCreate(BaseModel):
+    interactionId: int
+    creatorId: int
+    aprovalUserId: int
+    comment: str
+    interactionAprovalStateId: int
+
+
+class InteractionApprovalUpdate(BaseModel):
+    aprovalUserId: Optional[int] = None
+    comment: Optional[str] = None
+    interactionAprovalStateId: Optional[int] = None
+
+
 # 19️⃣ Task
 class Task(BaseModel):
     id: int
@@ -295,6 +337,48 @@ class ValidationApproval(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class ValidationCreate(BaseModel):
+    userId: int
+    code: str
+    name: str
+    requireReview: bool = False
+    description: str
+
+
+class ValidationUpdate(BaseModel):
+    code: Optional[str] = None
+    name: Optional[str] = None
+    requireReview: Optional[bool] = None
+    description: Optional[str] = None
+
+
+class ValidationParameterCreate(BaseModel):
+    interactionId: int
+    name: str
+    description: str
+    direction: bool = True
+
+
+class ValidationParameterUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    direction: Optional[bool] = None
+
+
+class ValidationApprovalCreate(BaseModel):
+    validationId: int
+    creatorId: int
+    aprovalUserId: int
+    comment: str
+    interactionAprovalStateId: int
+
+
+class ValidationApprovalUpdate(BaseModel):
+    aprovalUserId: Optional[int] = None
+    comment: Optional[str] = None
+    interactionAprovalStateId: Optional[int] = None
 
 
 # 24️⃣ Question


### PR DESCRIPTION
## Summary
- add dedicated CRUD/approval routes for interactions and validations
- extend schemas with create/update models
- plug the new routers into `main.py`

## Testing
- `pytest -q tests/test_permissions.py::test_role_permissions_flow -q`
- `pytest -q` *(fails: AuditEvent and other models missing)*

------
https://chatgpt.com/codex/tasks/task_e_686539cccbd0832fb4d3b52915a6e646