### PR TITLE
Improve performance analyst UI

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -68,6 +68,11 @@ export const routes: Routes = [
         canActivate: [() => import('./admin.guard').then(m => m.adminGuard)]
       },
       {
+        path: 'performance',
+        loadComponent: () => import('./components/performance/performance.component').then(m => m.PerformanceComponent),
+        canActivate: [() => import('./performance.guard').then(m => m.performanceGuard)]
+      },
+      {
         path: 'interactions',
         loadComponent: () => import('./components/interactions/interactions.component').then(m => m.InteractionsComponent)
       }

--- a/frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/frontend/src/app/components/main-layout/main-layout.component.ts
@@ -140,9 +140,12 @@ export class MainLayoutComponent implements OnInit {
       { label: 'Permisos', route: '/permissions', icon: '🔑' },
       { label: 'Agentes', route: '/agents', icon: '🤖' }
     ];
+    const perf = { label: 'Performance', route: '/performance', icon: '🚀' };
 
     if (this.currentUser?.role?.name === 'Administrador') {
-      this.menu = [...admin, ...base, ...extra];
+      this.menu = [...admin, perf, ...base, ...extra];
+    } else if (this.currentUser?.role?.name === 'Analista de Performance') {
+      this.menu = [perf, ...base, ...extra];
     } else {
       this.menu = [...base, ...extra];
     }

--- a/frontend/src/app/components/performance/performance-config-form.component.ts
+++ b/frontend/src/app/components/performance/performance-config-form.component.ts
@@ -1,0 +1,41 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+export interface PerformanceConfig {
+  vus: number;
+  rampUp: number;
+  duration: number;
+}
+
+@Component({
+  selector: 'app-performance-config-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <form (ngSubmit)="submit()" #form="ngForm" class="mb-3">
+      <div class="row g-2">
+        <div class="col">
+          <input type="number" class="form-control" name="vus" [(ngModel)]="config.vus" required min="1" placeholder="Usuarios">
+        </div>
+        <div class="col">
+          <input type="number" class="form-control" name="ramp" [(ngModel)]="config.rampUp" required min="0" placeholder="Ramp-up (s)">
+        </div>
+        <div class="col">
+          <input type="number" class="form-control" name="dur" [(ngModel)]="config.duration" required min="1" placeholder="Duración (s)">
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-success" [disabled]="form.invalid">Ejecutar</button>
+        </div>
+      </div>
+    </form>
+  `
+})
+export class PerformanceConfigFormComponent {
+  @Input() config: PerformanceConfig = { vus: 1, rampUp: 0, duration: 60 };
+  @Output() run = new EventEmitter<PerformanceConfig>();
+
+  submit() {
+    this.run.emit(this.config);
+  }
+}

--- a/frontend/src/app/components/performance/performance-results.component.ts
+++ b/frontend/src/app/components/performance/performance-results.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-performance-results',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="results; else empty">
+      <h3>Resultados</h3>
+      <pre>{{ results | json }}</pre>
+    </div>
+    <ng-template #empty>
+      <p class="text-secondary">No hay resultados</p>
+    </ng-template>
+  `
+})
+export class PerformanceResultsComponent {
+  @Input() results: any;
+}

--- a/frontend/src/app/components/performance/performance-scenario-selector.component.ts
+++ b/frontend/src/app/components/performance/performance-scenario-selector.component.ts
@@ -1,0 +1,36 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PerformanceService } from '../../services/performance.service';
+import { Scenario } from '../../models';
+
+@Component({
+  selector: 'app-performance-scenario-selector',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="mb-3">
+      <label class="form-label">Escenario</label>
+      <select class="form-select" [(ngModel)]="selectedId" (change)="onSelect()">
+        <option [ngValue]="null">Seleccione...</option>
+        <option *ngFor="let s of scenarios" [ngValue]="s.id">{{ s.name }}</option>
+      </select>
+    </div>
+  `
+})
+export class PerformanceScenarioSelectorComponent implements OnInit {
+  scenarios: Scenario[] = [];
+  selectedId: number | null = null;
+  @Output() selected = new EventEmitter<Scenario | null>();
+
+  constructor(private service: PerformanceService) {}
+
+  ngOnInit() {
+    this.service.getScenarios().subscribe(s => (this.scenarios = s));
+  }
+
+  onSelect() {
+    const sc = this.scenarios.find(s => s.id === this.selectedId) || null;
+    this.selected.emit(sc);
+  }
+}

--- a/frontend/src/app/components/performance/performance.component.ts
+++ b/frontend/src/app/components/performance/performance.component.ts
@@ -1,21 +1,39 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PerformanceService } from '../../services/performance.service';
+import { PerformanceScenarioSelectorComponent } from './performance-scenario-selector.component';
+import { PerformanceConfigFormComponent, PerformanceConfig } from './performance-config-form.component';
+import { PerformanceResultsComponent } from './performance-results.component';
+import { Scenario } from '../../models';
 
 @Component({
   selector: 'app-performance',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    PerformanceScenarioSelectorComponent,
+    PerformanceConfigFormComponent,
+    PerformanceResultsComponent
+  ],
   template: `
     <div class="main-panel">
       <h1>Motor de Performance</h1>
       <p class="text-secondary">Descarga el script de carga generado a partir de los tests funcionales.</p>
-      <button class="btn btn-primary" (click)="download()">Descargar Script K6</button>
+      <button class="btn btn-primary mb-3" (click)="download()">Descargar Script K6</button>
+
+      <app-performance-scenario-selector (selected)="onSelectScenario($event)"></app-performance-scenario-selector>
+
+      <app-performance-config-form (run)="runTest($event)" *ngIf="selectedScenario"></app-performance-config-form>
+
+      <app-performance-results [results]="results"></app-performance-results>
     </div>
   `,
   styles: []
 })
 export class PerformanceComponent {
+  selectedScenario: Scenario | null = null;
+  results: any;
+
   constructor(private service: PerformanceService) {}
 
   download() {
@@ -26,6 +44,20 @@ export class PerformanceComponent {
       a.download = 'script.js';
       a.click();
       URL.revokeObjectURL(url);
+    });
+  }
+
+  onSelectScenario(s: Scenario | null) {
+    this.selectedScenario = s;
+    this.results = null;
+  }
+
+  runTest(cfg: PerformanceConfig) {
+    if (!this.selectedScenario) {
+      return;
+    }
+    this.service.startTest(this.selectedScenario.id, cfg).subscribe(r => {
+      this.results = r;
     });
   }
 }

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -359,3 +359,10 @@ export interface Feature {
   description: string;
   status: boolean;
 }
+
+export interface Scenario {
+  id: number;
+  name: string;
+  description?: string;
+  status: boolean;
+}

--- a/frontend/src/app/performance.guard.ts
+++ b/frontend/src/app/performance.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { ApiService } from './services/api.service';
+import { of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export const performanceGuard: CanActivateFn = () => {
+  const api = inject(ApiService);
+  const router = inject(Router);
+
+  if (!api.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  return api.getCurrentUser().pipe(
+    map(user =>
+      user.role?.name === 'Analista de Performance'
+        ? true
+        : router.createUrlTree(['/'])
+    ),
+    catchError(() => of(router.createUrlTree(['/'])))
+  );
+};

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -12,6 +12,7 @@ import {
   LoginRequest, LoginResponse, UserRoleUpdate, PendingExecution,
   MarketplaceComponent, MarketplaceComponentCreate,
   Task, Interaction, Validation, Question, RawData, Feature,
+  Scenario,
   PagePermission, PagePermissionCreate, ApiPermission, ApiPermissionCreate
 } from '../models';
 
@@ -577,6 +578,20 @@ export class ApiService {
 
   createRawData(r: RawData): Observable<RawData> {
     return this.http.post<RawData>(`${this.baseUrl}/rawdata/`, r, { headers: this.getHeaders() });
+  }
+
+  // Scenarios
+  getScenarios(): Observable<Scenario[]> {
+    return this.http.get<Scenario[]>(`${this.baseUrl}/scenarios/`, { headers: this.getHeaders() });
+  }
+
+  // Performance execution
+  runPerformanceTest(cfg: any): Observable<any> {
+    return this.http.post(`${this.baseUrl}/k6/run`, cfg, { headers: this.getHeaders() });
+  }
+
+  getPerformanceResults(): Observable<any> {
+    return this.http.get(`${this.baseUrl}/k6/results`, { headers: this.getHeaders() });
   }
 
   isAuthenticated(): boolean {

--- a/frontend/src/app/services/performance.service.ts
+++ b/frontend/src/app/services/performance.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
+import { Scenario } from '../models';
+import { PerformanceConfig } from '../components/performance/performance-config-form.component';
 
 @Injectable({ providedIn: 'root' })
 export class PerformanceService {
@@ -8,5 +10,17 @@ export class PerformanceService {
 
   downloadK6Script(): Observable<Blob> {
     return this.api.downloadK6Script();
+  }
+
+  getScenarios(): Observable<Scenario[]> {
+    return this.api.getScenarios();
+  }
+
+  startTest(scenarioId: number, cfg: PerformanceConfig): Observable<any> {
+    return this.api.runPerformanceTest({ scenario_id: scenarioId, ...cfg });
+  }
+
+  getResults(): Observable<any> {
+    return this.api.getPerformanceResults();
   }
 }


### PR DESCRIPTION
## Summary
- add Scenario interface
- create guard and components for performance features
- enhance menu and routes for performance analyst
- expand performance service and API service

## Testing
- `npm run build -- --configuration=development`
- `pytest -q` *(fails: AttributeError and 404)*

------
https://chatgpt.com/codex/tasks/task_e_68653ae123d4832f9a879a8c8c63ede7