### PR TITLE
Add e2e test for disabled user login

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -69,6 +69,8 @@ def authenticate_user(db: Session, username: str, password: str):
         return False
     if not verify_password(password, user.password):
         return False
+    if not user.is_active:
+        return False
     return user
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -270,7 +270,7 @@ register_cruds()
 for r in all_routers:
     app.include_router(r)
 
-from .routes import routers as custom_routers
+from .routes import all_routers as custom_routers
 
 for r in custom_routers:
     app.include_router(r)

--- a/tests/e2e/test_user_deactivation.py
+++ b/tests/e2e/test_user_deactivation.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def login(username: str, password: str) -> str:
+    resp = client.post("/token", data={"username": username, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_disabled_user_cannot_login():
+    admin_token = login("admin", "admin")
+
+    resp = client.get("/users/", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    users = resp.json()
+    target = next(u for u in users if u["username"] == "architect")
+
+    user_id = target["id"]
+    role_id = target["role_id"]
+
+    update = {
+        "id": user_id,
+        "username": "architect",
+        "password": "admin",
+        "last_login": None,
+        "is_active": False,
+        "endSubscriptionDate": None,
+        "role_id": role_id,
+    }
+    resp = client.put(
+        f"/users/{user_id}",
+        json=update,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.post("/token", data={"username": "architect", "password": "admin"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- prevent login for inactive users
- fix routes import in `backend.app.main`
- add e2e test to ensure a disabled user cannot log in

## Testing
- `pytest tests/e2e/test_user_deactivation.py::test_disabled_user_cannot_login -q`
- `pytest -q` *(fails: AttributeError: module 'backend.app.models' has no attribute 'AuditEvent', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686545f9b7f4832f81f0d724f66abd51