### PR TITLE
Add private route test

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -5,3 +5,6 @@ all_routers = [
     digital_assets.router,
     projects.router,
 ]
+
+# Compatibility alias expected by main.py and some tests
+routers = all_routers

--- a/tests/e2e/test_private_routes.py
+++ b/tests/e2e/test_private_routes.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+def test_private_routes_require_auth():
+    resp = client.get("/clients/")
+    assert resp.status_code == 401
+
+    resp = client.get("/projects/")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- fix router import in backend app
- add e2e test to verify authentication is required for private routes

## Testing
- `pytest -q tests/e2e/test_private_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_686546219988832f824d086fe5742bfe