### PR TITLE
Add e2e start page test

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -5,3 +5,6 @@ all_routers = [
     digital_assets.router,
     projects.router,
 ]
+
+# Backwards compatibility for legacy imports
+routers = all_routers

--- a/tests/e2e/test_start_page.py
+++ b/tests/e2e/test_start_page.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///" + tempfile.mktemp(suffix=".db")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app import models, deps
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+def _login(username: str, password: str) -> str:
+    resp = client.post("/token", data={"username": username, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+def test_start_page_after_login():
+    db = SessionLocal()
+    role = models.Role(name="DemoRole", description="demo")
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+
+    perm = models.PagePermission(page="/demo", role_id=role.id, isStartPage=True)
+    db.add(perm)
+
+    user = models.User(
+        username="demouser",
+        password=deps.get_password_hash("demo"),
+        role_id=role.id,
+    )
+    db.add(user)
+    db.commit()
+    db.close()
+
+    token = _login("demouser", "demo")
+    resp = client.get(
+        f"/roles/{role.id}/permissions",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    perms = resp.json()
+    start = next((p for p in perms if p["isStartPage"]), None)
+    assert start is not None
+    assert start["page"] == "/demo"


### PR DESCRIPTION
## Summary
- add `routers` alias in backend routes to fix import
- create `test_start_page_after_login` end-to-end test

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: DetachedInstanceError and others)*

------
https://chatgpt.com/codex/tasks/task_e_686546321a54832f9a79ab2d21e2162c