### PR TITLE
Add basic Chrome navigation e2e test

### DIFF
--- a/tests/e2e/Navigator/test_chrome_navigation.py
+++ b/tests/e2e/Navigator/test_chrome_navigation.py
@@ -1,0 +1,11 @@
+from playwright.sync_api import sync_playwright
+
+
+def test_chrome_navigates_example():
+    """Simple Playwright example using Chromium headless browser."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto("http://example.com", wait_until="networkidle")
+        assert "Example Domain" in page.title()
+        browser.close()


### PR DESCRIPTION
## Summary
- add Navigator folder and Playwright test using Chromium

## Testing
- `pytest -q tests/e2e/Navigator/test_chrome_navigation.py`
- `pytest -q tests/e2e/Navigator`

------
https://chatgpt.com/codex/tasks/task_e_68654a4b46d0832fbdbbcf375d7c15ab