### PR TITLE
Fix missing brace in ApiService

### DIFF
--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -629,6 +629,7 @@ export class ApiService {
 
   rejectValidation(id: number): Observable<any> {
     return this.http.post(`${this.baseUrl}/validationapprovals/${id}/reject`, {}, { headers: this.getHeaders() });
+  }
 
   // Scenarios
   getScenarios(): Observable<Scenario[]> {


### PR DESCRIPTION
## Summary
- fix missing closing brace for `rejectValidation`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_686554c79b10832facbdf50412c052c1